### PR TITLE
Add monitors objects

### DIFF
--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -51,33 +51,33 @@ class PluginSccmSccm {
       $PluginSccmSccmdb = new PluginSccmSccmdb();
       $PluginSccmSccmdb->connect();
 
-      $query = "SELECT csd.Description00 as \"CSD-Description\",
-      csd.Domain00 as \"CSD-Domain\",
-      csd.Manufacturer00 as \"CSD-Manufacturer\",
-      csd.Model00 as \"CSD-Model\",
-      csd.Roles00 as \"CSD-Roles\",
-      csd.SystemType00 as \"CSD-SystemType\",
-      csd.UserName00 as \"CSD-UserName\",
-      csd.MachineID as \"CSD-MachineID\",
-      csd.TimeKey as \"CSD-TimeKey\",
-      md.SystemName00 as \"MD-SystemName\",
-      osd.BuildNumber00 as \"OSD-BuildNumber\",
-      osd.Caption00 as \"OSD-Caption\",
-      osd.CSDVersion00 as \"OSD-CSDVersion\",
-      osd.BootDevice00 as \"OSD-BootDevice\",
-      osd.InstallDate00 as \"OSD-InstallDate\",
-      osd.LastBootUpTime00 as \"OSD-LastBootUpTime\",
-      osd.Manufacturer00 as \"OSD-Manufacturer\",
-      osd.Name00 as \"OSD-Name\",
-      osd.Organization00 as \"OSD-Organization\",
-      osd.RegisteredUser00 as \"OSD-RegisteredUser\",
-      osd.TotalVirtualMemorySize00 as \"OSD-TotalVirtualMemory\",
-      osd.TotalVisibleMemorySize00 as \"OSD-TotalVisibleMemory\",
-      osd.Version00 as \"OSD-Version\",
-      pbd.SerialNumber00 as \"PBD-SerialNumber\",
-      pbd.ReleaseDate00 as \"PBD-ReleaseDate\",
-      pbd.Name00 as \"PBD-Name\",
-      pbd.SMBIOSBIOSVersion00 as \"PBD-BiosVersion\",
+      $query = "SELECT csd.Description00 as \"CSD-Description\", 
+      csd.Domain00 as \"CSD-Domain\", 
+      csd.Manufacturer00 as \"CSD-Manufacturer\", 
+      csd.Model00 as \"CSD-Model\", 
+      csd.Roles00 as \"CSD-Roles\", 
+      csd.SystemType00 as \"CSD-SystemType\", 
+      csd.UserName00 as \"CSD-UserName\", 
+      csd.MachineID as \"CSD-MachineID\", 
+      csd.TimeKey as \"CSD-TimeKey\", 
+      md.SystemName00 as \"MD-SystemName\", 
+      osd.BuildNumber00 as \"OSD-BuildNumber\", 
+      osd.Caption00 as \"OSD-Caption\", 
+      osd.CSDVersion00 as \"OSD-CSDVersion\", 
+      osd.BootDevice00 as \"OSD-BootDevice\",  
+      osd.InstallDate00 as \"OSD-InstallDate\", 
+      osd.LastBootUpTime00 as \"OSD-LastBootUpTime\", 
+      osd.Manufacturer00 as \"OSD-Manufacturer\", 
+      osd.Name00 as \"OSD-Name\", 
+      osd.Organization00 as \"OSD-Organization\", 
+      osd.RegisteredUser00 as \"OSD-RegisteredUser\", 
+      osd.TotalVirtualMemorySize00 as \"OSD-TotalVirtualMemory\", 
+      osd.TotalVisibleMemorySize00 as \"OSD-TotalVisibleMemory\", 
+      osd.Version00 as \"OSD-Version\", 
+      pbd.SerialNumber00 as \"PBD-SerialNumber\", 
+      pbd.ReleaseDate00 as \"PBD-ReleaseDate\", 
+      pbd.Name00 as \"PBD-Name\", 
+      pbd.SMBIOSBIOSVersion00 as \"PBD-BiosVersion\", 
       pbd.Version00 as \"PBD-Version\",
       pbd.Manufacturer00 as \"PBD-Manufacturer\",
       sdi.User_Name0 as \"SDI-UserName\",
@@ -90,7 +90,7 @@ class PluginSccmSccm {
       LEFT JOIN PC_BIOS_DATA pbd ON csd.MachineID = pbd.MachineID
       LEFT JOIN System_DISC sdi ON csd.MachineID = sdi.ItemKey
       LEFT JOIN System_DATA sd ON csd.MachineID = sd.MachineID
-      INNER JOIN v_R_System VrS ON csd.MachineID = VrS.ResourceID
+      INNER JOIN v_R_System VrS ON csd.MachineID = VrS.ResourceID 
       ";
 
       if($where!=0) {
@@ -100,16 +100,8 @@ class PluginSccmSccm {
       $result = $PluginSccmSccmdb->exec_query($query);
 
       $i = 0;
-      $tab = array();
 
-      if(function_exists('sqlsrv_fetch_array')) {
-         $tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $tab = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-      while($tab AND $i < $limit) {
+      while($tab = mssql_fetch_array($result, MSSQL_ASSOC) AND $i < $limit) {
 
          $tab['MD-SystemName'] = strtoupper($tab['MD-SystemName']);
 
@@ -122,12 +114,17 @@ class PluginSccmSccm {
    }
 
    function getDatas($type, $deviceid) {
-
+      
       $PluginSccmSccmdb = new PluginSccmSccmdb();
       $PluginSccmSccmdb->connect();
 
-      $datas = array();
+      if(preg_match("#_#",$deviceid)) {
+         $deviceid = explode("_",$deviceid);
+         $deviceid = $deviceid[1];
+      }
 
+      $datas = array();
+      
       switch($type){
          case 'drives':
             $fields = array('Caption00','Description00','DeviceID00','InterfaceType00',
@@ -139,23 +136,14 @@ class PluginSccmSccm {
             $table = 'Processor_DATA';
          break;
       }
-
+      
       $query = "SELECT ".implode(',',$fields)."\n";
       $query.= " FROM ".$table."\n";
       $query.= " WHERE MachineID = '".$deviceid."'"."\n";
 
       $result = $PluginSccmSccmdb->exec_query($query);
-
-      $data = array();
-      if(function_exists('sqlsrv_fetch_array')) {
-         $data = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $data = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-      while($data) {
-
+      $conpteur=$conpteur+1;
+      while($data = mssql_fetch_array($result, MSSQL_ASSOC)) {
          foreach($data as $key => $value){
             $data[$key] = $this->cleanValue($value);
          }
@@ -168,44 +156,37 @@ class PluginSccmSccm {
    }
 
    function cleanValue($value) {
-      $value = Html::clean($value);
       $value = Toolbox::clean_cross_side_scripting_deep($value);
       $value = Toolbox::addslashes_deep($value);
       return $value;
    }
 
    function getNetwork($deviceid) {
-
+      
       $PluginSccmSccmdb = new PluginSccmSccmdb();
       $PluginSccmSccmdb->connect();
 
+      if(preg_match("#_#",$deviceid)) {
+         $deviceid = explode("_",$deviceid);
+         $deviceid = $deviceid[1];
+      }
+
       $query = "SELECT NeDa.IPAddress00 as \"ND-IpAddress\",
-      NeDa.MACAddress00 as \"ND-MacAddress\",
-      NeDa.IPSubnet00 as \"ND-IpSubnet\",
-      NeDa.DefaultIPGateway00 as \"ND-IpGateway\",
-      NeDa.DHCPServer00 as \"ND-DHCPServer\",
+      NeDa.MACAddress00 as \"ND-MacAddress\", 
+      NeDa.IPSubnet00 as \"ND-IpSubnet\", 
+      NeDa.DefaultIPGateway00 as \"ND-IpGateway\", 
+      NeDa.DHCPServer00 as \"ND-DHCPServer\", 
       NeDa.DNSDomain00 as \"ND-DomainName\",
-      net.Name0 as \"ND-Name\"
+      NeDa.ServiceName00 as \"ND-Name\"
       FROM Network_DATA NeDa
       INNER JOIN v_R_System VrS ON VrS.ResourceID=NeDa.MachineID
-      INNER JOIN v_GS_NETWORK_ADAPTER net ON net.ResourceID=NeDa.MachineID AND NeDa.ServiceName00=net.ServiceName0
       WHERE NeDa.IPEnabled00=1
       AND NeDa.MachineID = '".$deviceid."'";
-
+      
       $datas = array();
 
       $result = $PluginSccmSccmdb->exec_query($query);
-
-      $data = array();
-      if(function_exists('sqlsrv_fetch_array')) {
-         $data = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $data = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-      while($data) {
-
+      while($data = mssql_fetch_array($result, MSSQL_ASSOC)) {
          foreach($data as $key => $value){
             $data[$key] = $this->cleanValue($value);
          }
@@ -222,6 +203,11 @@ class PluginSccmSccm {
       $PluginSccmSccmdb = new PluginSccmSccmdb();
       $PluginSccmSccmdb->connect();
 
+      if(preg_match("#_#",$deviceid)) {
+         $deviceid = explode("_",$deviceid);
+         $deviceid = $deviceid[1];
+      }
+
       $query = "SELECT ArPd.DisplayName00 as \"ArPd-DisplayName\",
       ArPd.InstallDate00 as \"ArPd-InstallDate\",
       ArPd.Version00 as \"ArPd-Version\",
@@ -229,20 +215,11 @@ class PluginSccmSccm {
       FROM Add_Remove_Programs_DATA ArPd
       INNER JOIN v_R_System VrS on VrS.ResourceID=ArPd.MachineID
       WHERE ArPd.MachineID = '".$deviceid."'";
-
+      
       $datas = array();
 
       $result = $PluginSccmSccmdb->exec_query($query);
-
-      $data = array();
-      if(function_exists('sqlsrv_fetch_array')) {
-         $data = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $data = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-      while($data) {
+      while($data = mssql_fetch_array($result, MSSQL_ASSOC)) {
          foreach($data as $key => $value){
             $data[$key] = utf8_encode($this->cleanValue($value));
          }
@@ -254,41 +231,26 @@ class PluginSccmSccm {
       return $datas;
    }
 
-   function getMemories($deviceid) {
+   function getMonitors($deviceid) {
 
       $PluginSccmSccmdb = new PluginSccmSccmdb();
       $PluginSccmSccmdb->connect();
 
-      $query = "SELECT
-				Capacity0 as \"Mem-Capacity\",
-				Caption0 as \"Mem-Caption\",
-				Description0 as \"Mem-Description\",
-				FormFactor0 as \"Mem-FormFactor\",
-				Removable0 as \"Mem-Removable\",
-				'' as \"Mem-Purpose\",
-				Speed0 as \"Mem-Speed\",
-				BankLabel0 as \"Mem-Type\",
-				GroupID as \"Mem-NumSlots\",
-				'' as \"Mem-SerialNumber\"
-			FROM v_GS_PHYSICAL_MEMORY
+      if(preg_match("#_#",$deviceid)) {
+         $deviceid = explode("_",$deviceid);
+         $deviceid = $deviceid[1];
+      }
 
-			WHERE ResourceID = '".$deviceid."'
-
-			ORDER BY \"Mem-NumSlots\"";
-
+      $query = "SELECT mddata.Manufacturer00 as \"mddata-Manufacturer\", 
+      mddata.DiagonalSize00 as \"mddata-DiagonalSize\", mddata.Name00 as \"mddata.Name\",
+      mddata.SerialNumber00 as \"mddata-SerialNumber\" FROM MonitorDetails_DATA mddata
+      INNER JOIN v_R_System VrS on VrS.ResourceID=mddata.MachineID
+      WHERE mddata.MachineID = '".$deviceid."' ";
+      
       $datas = array();
 
       $result = $PluginSccmSccmdb->exec_query($query);
-
-      $data = array();
-      if(function_exists('sqlsrv_fetch_array')) {
-         $data = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $data = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-      while($data) {
+      while($data = mssql_fetch_array($result, MSSQL_ASSOC)) {
          foreach($data as $key => $value){
             $data[$key] = utf8_encode($this->cleanValue($value));
          }
@@ -299,168 +261,9 @@ class PluginSccmSccm {
 
       return $datas;
    }
-
-   function getVideos($deviceid) {
-
-		$PluginSccmSccmdb = new PluginSccmSccmdb();
-		$PluginSccmSccmdb->connect();
-
-		$query = "
-  		SELECT
-  			VideoProcessor0 as \"Vid-Chipset\",
-  			AdapterRAM0/1024 as \"Vid-Memory\",
-  			Name0 as \"Vid-Name\",
-  			CONCAT(CurrentHorizontalResolution0, 'x', CurrentVerticalResolution0) as \"Vid-Resolution\",
-  			GroupID as \"Vid-PciSlot\"
-  		FROM v_GS_VIDEO_CONTROLLER
-  		WHERE VideoProcessor0 is not null
-  		AND ResourceID = '".$deviceid."'
-  		ORDER BY GroupID";
-
-		$datas = array();
-
-		$result = $PluginSccmSccmdb->exec_query($query);
-
-      $data = array();
-      if(function_exists('sqlsrv_fetch_array')) {
-         $data = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $data = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-		while($data) {
-			foreach($data as $key => $value){
-				$data[$key] = utf8_encode($this->cleanValue($value));
-			}
-			$datas[]=$data;
-		}
-
-		$PluginSccmSccmdb->disconnect();
-
-		return $datas;
-	 }
-
-   function getSounds($deviceid) {
-
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $PluginSccmSccmdb->connect();
-
-      $query = "
-      SELECT distinct
-         Description0 as \"Snd-Description\",
-         Manufacturer0 as \"Snd-Manufacturer\",
-         Name0 as \"Snd-Name\"
-      FROM v_GS_SOUND_DEVICE
-      WHERE ResourceID = '".$deviceid."'";
-
-      $datas = array();
-
-      $result = $PluginSccmSccmdb->exec_query($query);
-
-      $data = array();
-      if(function_exists('sqlsrv_fetch_array')) {
-         $data = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $data = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-      while($data) {
-         foreach($data as $key => $value){
-            $data[$key] = utf8_encode($this->cleanValue($value));
-         }
-         $datas[]=$data;
-      }
-
-      $PluginSccmSccmdb->disconnect();
-
-      return $datas;
-   }
-
-   function getStorages($deviceid) {
-
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $PluginSccmSccmdb->connect();
-
-      $query = "
-      SELECT distinct
-         Description0 as \"Sto-Description\",
-         InterfaceType0 as \"Sto-Interface\",
-         Manufacturer0 as \"Sto-Manufacturer\",
-         Model0 as \"Sto-Model\",
-         Name0 as \"Sto-Name\",
-         SCSITargetID0 as \"Sto-SCSITargetId\",
-         MediaType0 as \"Sto-Type\",
-         Size0 as \"Sto-Size\"
-      FROM v_GS_DISK
-      WHERE ResourceID = '".$deviceid."'";
-
-      $datas = array();
-
-      $result = $PluginSccmSccmdb->exec_query($query);
-
-      $data = array();
-      if(function_exists('sqlsrv_fetch_array')) {
-         $data = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $data = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-      while($data) {
-         foreach($data as $key => $value){
-            $data[$key] = utf8_encode($this->cleanValue($value));
-         }
-         $datas[]=$data;
-      }
-
-      $PluginSccmSccmdb->disconnect();
-
-      return $datas;
-   }
-
-   function getMedias($deviceid) {
-
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $PluginSccmSccmdb->connect();
-
-      $query = "
-      SELECT distinct
-         Description0 as \"Med-Description\",
-         Manufacturer0 as \"Med-Manufacturer\",
-         Caption0 as \"Med-Model\",
-         Name0 as \"Med-Name\",
-         SCSITargetID0 as \"Med-SCSITargetId\",
-         MediaType0 as \"Med-Type\"
-      FROM v_GS_CDROM
-      WHERE ResourceID = '".$deviceid."'";
-
-      $datas = array();
-
-      $result = $PluginSccmSccmdb->exec_query($query);
-
-      $data = array();
-      if(function_exists('sqlsrv_fetch_array')) {
-         $data = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC);
-      }
-      elseif(function_exists('mssql_fetch_array')) {
-         $data = mssql_fetch_array($result, MSSQL_ASSOC);
-      }
-
-      while($data) {
-
-         foreach($data as $key => $value){
-            $data[$key] = utf8_encode($this->cleanValue($value));
-         }
-         $datas[]=$data;
-      }
-
-      $PluginSccmSccmdb->disconnect();
-
-      return $datas;
-   }
-
+    
+    
+    
    static function install() {
       $cron = new CronTask;
       if (!$cron->getFromDBbyName(__CLASS__, 'sccm')) {
@@ -497,7 +300,7 @@ class PluginSccmSccm {
          $PluginSccmSccm->getDevices();
          Toolbox::logInFile('sccm', "getDevices OK \n", true);
 
-         Toolbox::logInFile('sccm', "Generate XML start : "
+         Toolbox::logInFile('sccm', "Generate XML start : " 
             . count($PluginSccmSccm->devices) . " files\n", true);
 
          foreach($PluginSccmSccm->devices as $device_values) {
@@ -511,13 +314,10 @@ class PluginSccmSccm {
             $PluginSccmSccmxml->setBios();
             $PluginSccmSccmxml->setProcessors();
             $PluginSccmSccmxml->setSoftwares();
-            $PluginSccmSccmxml->setMemories();
-            $PluginSccmSccmxml->setVideos();
-            $PluginSccmSccmxml->setSounds();
             $PluginSccmSccmxml->setUsers();
             $PluginSccmSccmxml->setNetworks();
             $PluginSccmSccmxml->setDrives();
-            $PluginSccmSccmxml->setStorages();
+            $PluginSccmSccmxml->setMonitors();
 
             $SXML = $PluginSccmSccmxml->sxml;
 
@@ -544,3 +344,4 @@ class PluginSccmSccm {
    }
 
 }
+?>

--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -48,7 +48,7 @@ class PluginSccmSccmxml {
       $plug->getFromDBbyDir("sccm");
 
       $this->data = $data;
-      $this->device_id = $data['CSD-MachineID'];
+      $this->device_id = $data['MD-SystemName']."_".$data['CSD-MachineID'];
       $this->agentbuildnumber = "SCCM-v".$plug->fields['version'];
 
 $SXML=<<<XML
@@ -111,7 +111,7 @@ XML;
       
       $HARDWARE = $this->sxml->CONTENT[0]->HARDWARE;
       $HARDWARE->addChild('NAME',strtoupper($this->data['MD-SystemName']));
-      //$HARDWARE->addChild('CHASSIS_TYPE',$this->data['SD-SystemRole']);
+      $HARDWARE->addChild('CHASSIS_TYPE',$this->data['SD-SystemRole']);
       $HARDWARE->addChild('LASTLOGGEDUSER',$this->username);
       $HARDWARE->addChild('UUID',substr($this->data['SD-UUID'],5));
    }
@@ -219,67 +219,6 @@ XML;
       }
    }
 
-   function setMemories() {
-		$PluginSccmSccm = new PluginSccmSccm();
-
-		$CONTENT = $this->sxml->CONTENT[0]; $i = 0;
-		foreach($PluginSccmSccm->getMemories($this->device_id) as $value){
-
-			$CONTENT->addChild('MEMORIES');
-			$MEMORIES = $this->sxml->CONTENT[0]->MEMORIES[$i];
-
-			$MEMORIES->addChild('CAPACITY', $value['Mem-Capacity']);
-			$MEMORIES->addChild('CAPTION', $value['Mem-Caption']);
-			$MEMORIES->addChild('DESCRIPTION', $value['Mem-Description']);
-			$MEMORIES->addChild('FORMFACTOR', $value['Mem-FormFactor']);
-			$MEMORIES->addChild('REMOVABLE', $value['Mem-Removable']);
-			$MEMORIES->addChild('PURPOSE', $value['Mem-Purpose']);
-			$MEMORIES->addChild('SPEED', $value['Mem-Speed']);
-			$MEMORIES->addChild('TYPE', $value['Mem-Type']);
-			$MEMORIES->addChild('NUMSLOTS', $value['Mem-NumSlots']);
-			$MEMORIES->addChild('SERIALNUMBER', $value['Mem-SerialNumber']);
-
-			$i++;
-		}
-
-	 }
-
-   function setVideos() {
-		$PluginSccmSccm = new PluginSccmSccm();
-
-		$CONTENT = $this->sxml->CONTENT[0]; $i = 0;
-		foreach($PluginSccmSccm->getVideos($this->device_id) as $value){
-
-			$CONTENT->addChild('VIDEOS');
-			$VIDEOS = $this->sxml->CONTENT[0]->VIDEOS[$i];
-
-			$VIDEOS->addChild('CHIPSET', $value['Vid-Chipset']);
-			$VIDEOS->addChild('MEMORY', $value['Vid-Memory']);
-			$VIDEOS->addChild('NAME', $value['Vid-Name']);
-			$VIDEOS->addChild('RESOLUTION', $value['Vid-Resolution']);
-			$VIDEOS->addChild('PCISLOT', $value['Vid-PciSlot']);
-
-			$i++;
-		}  
-	 }
-
-   function setSounds() {
-      $PluginSccmSccm = new PluginSccmSccm();
-
-      $CONTENT = $this->sxml->CONTENT[0]; $i = 0;
-      foreach($PluginSccmSccm->getSounds($this->device_id) as $value){
-
-         $CONTENT->addChild('SOUNDS');
-         $SOUNDS = $this->sxml->CONTENT[0]->SOUNDS[$i];
-
-         $SOUNDS->addChild('DESCRIPTION', $value['Snd-Description']);
-         $SOUNDS->addChild('MANUFACTURER', $value['Snd-Manufacturer']);
-         $SOUNDS->addChild('NAME', $value['Snd-Name']);
-
-         $i++;
-      }
-    }
-
    function setAntivirus($value) {
       $CONTENT    = $this->sxml->CONTENT[0];
       $CONTENT->addChild('ANTIVIRUS');
@@ -345,39 +284,22 @@ XML;
       }
    }
 
-   function setStorages() {
+   function setMonitors() {
       $PluginSccmSccm = new PluginSccmSccm();
 
       $CONTENT    = $this->sxml->CONTENT[0]; $i = 0;
-      foreach($PluginSccmSccm->getStorages($this->device_id) as $value){
-         $CONTENT->addChild('STORAGES');
-         $STORAGES = $this->sxml->CONTENT[0]->STORAGES[$i];
-         $STORAGES->addChild('DESCRIPTION', $value['Sto-Description']);
-         $STORAGES->addChild('DISKSIZE', $value['Sto-Size']);
-         $STORAGES->addChild('INTERFACE', $value['Sto-Interface']);
-         $STORAGES->addChild('MANUFACTURER', $value['Stro-Manufacturer']);
-         $STORAGES->addChild('MODEL', $value['Sto-Model']);
-         $STORAGES->addChild('NAME', $value['Sto-Name']);
-         $STORAGES->addChild('SCSI_COID', $value['Sto-SCSITargetId']);
-         $STORAGES->addChild('SCSI_LUN', 0);
-         $STORAGES->addChild('SCSI_UNID', 0);
-         $STORAGES->addChild('TYPE', $value['Sto-Type']);
-         $i++;
-      }
 
-      foreach($PluginSccmSccm->getMedias($this->device_id) as $value){
-         $CONTENT->addChild('STORAGES');
-         $STORAGES = $this->sxml->CONTENT[0]->STORAGES[$i];
-         $STORAGES->addChild('DESCRIPTION', $value['Med-Description']);
-         $STORAGES->addChild('MANUFACTURER', $value['Med-Manufacturer']);
-         $STORAGES->addChild('MODEL', $value['Med-Model']);
-         $STORAGES->addChild('NAME', $value['Med-Name']);
-         $STORAGES->addChild('SCSI_COID', $value['Med-SCSITargetId']);
-         $STORAGES->addChild('SCSI_LUN', 0);
-         $STORAGES->addChild('SCSI_UNID', 0);
-         $STORAGES->addChild('TYPE', $value['Med-Type']);
+    // note fusion inventory ne remonte que ces 3 valeurs
+      foreach($PluginSccmSccm->getMonitors($this->device_id) as $value){
+         $CONTENT->addChild('MONITORS');
+         $MONITORS = $this->sxml->CONTENT[0]->MONITORS[$i];
+         $MONITORS->addChild('MANUFACTURER'     ,$value['mddata-Manufacturer']);
+         $MONITORS->addChild('CAPTION'       ,$value['mddata.Name']." (".$value['mddata-DiagonalSize']."\")" );
+         $MONITORS->addChild('SERIAL'        ,$value['mddata-SerialNumber']);
+
          $i++;
-      }
+    }
+
    }
 
    function object2array($object) { 

--- a/setup.php
+++ b/setup.php
@@ -54,14 +54,14 @@ function plugin_version_sccm() {
                'author'         => 'TECLIB\'',
                'license'        => 'GPLv2+',
                'homepage'       => 'http://www.teclib.com',
-               'minGlpiVersion' => '0.85');
+               'minGlpiVersion' => '9.1');
 }
 
 function plugin_sccm_check_prerequisites() {
 
-   if (version_compare(GLPI_VERSION,'0.85','lt') 
-         || version_compare(GLPI_VERSION,'0.91','ge')) {
-      echo "This plugin requires GLPI = 0.85";
+   if (version_compare(GLPI_VERSION,'9.1','lt') 
+         || version_compare(GLPI_VERSION,'9.2','ge')) {
+      echo "This plugin requires GLPI = 9.1-9.2";
       return false;
    }
    return true;
@@ -72,9 +72,9 @@ function plugin_sccm_check_config($verbose=false) {
       echo "cURL extension (PHP) is required.";
       return false;
    }
-   if (!function_exists('mssql_connect') && !function_exists('sqlsrv_connect')) {
-      echo "MS-SQL extension (PHP) is required.";
+/*   if (!function_exists('mssql_connect')) {
+      echo "MsSQL extension (PHP) is required.";
       return false;
-   }
+   }*/
    return true;
 }


### PR DESCRIPTION
Adding monitors in the synchro. 

Hi, we’ve added a piece of code to sync monitors.
It seems that the plug-in has evolved since last download, so maybe just extract the methods below to produce a new version. (just uploaded the changed files.)
changes :
- updated the version in the setup 9.1-9.2 for allowing install in
v9.1.x.
- Add function getMonitors($deviceid) {
- Add function setMonitors() {
in  static function install() {:
- add $PluginSccmSccmxml->setMonitors();

This requires a script to execute in workstations see : https://sccmshenanigans.blogspot.fr/2013/11/custom-wmi-classes-and-reporting-into.html to add monitors to the WMI.

(dedicated table in MSSQL : MonitorDetails_DATA)

Tested with GLPI 9.1 @ 9.1.2.
For large assets number it is essential to increase the memory limit to 1-2G of ram  in the php.ini and also increase the execution time limit. (we’ve put 0 to have no limit )
In our testing environnement we have about 4K workstations, the scripts works fine with no issues. 
 (fusioninventory latest release 9.0)
The script duration in our case  is about 20-30 min (do not worries ) and requires some HW ressources, in our case allocating 3-4 vCPUs and 4-8 Go of RAM is recommended. Be carefull about opening the appropriate ports ( i.e. : )
For those interested, we used the free MS VM WIN2008R2 with MSSQL for developing & testing.
(https://www.microsoft.com/en-ca/download/details.aspx?id=26113) But you need to populate sample datas.

Hope it helps others.