### PR TITLE
Fix return code in cron tasks

### DIFF
--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -492,13 +492,11 @@ class PluginSccmSccm {
    }
 
    static function cronSCCMCollect($task) {
-      self::executeCollect($task);
-      return true;
+      return self::executeCollect($task);
    }
 
    static function cronSCCMPush($task) {
-      self::executePush($task);
-      return true;
+      return self::executePush($task);
    }
 
    static function cronInfo($name) {
@@ -561,7 +559,8 @@ class PluginSccmSccm {
       } else {
          echo __("Collect is disabled by configuration.", "sccm");
       }
-      $task->end($retcode);
+
+      return $retcode;
    }
 
 
@@ -651,7 +650,8 @@ class PluginSccmSccm {
       } else {
          echo __("Push is disabled by configuration.", "sccm");
       }
-      $task->end($retcode);
+
+      return $retcode;
    }
 
 }


### PR DESCRIPTION
1. cron task end is called by GLPI core and should not be called by task itself, see https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/crontask.class.php#L833
2. cron task methods return must be numeric, see https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/crontask.class.php#L272