### PR TITLE
feat(core): use SCCM last scan as FusionInventory last inventory

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -92,6 +92,7 @@ class PluginSccmConfig extends CommonDBTM {
                      `use_auth_info` tinyint(1) NOT NULL,
                      `auth_info` VARCHAR(255) NULL,
                      `is_password_sodium_encrypted` tinyint(1) NOT NULL default '1',
+                     `use_lasthwscan` tinyint(1) NOT NULL,
                      `date_mod` timestamp NULL default NULL,
                      `comment` text,
                      PRIMARY KEY  (`id`)
@@ -154,6 +155,11 @@ class PluginSccmConfig extends CommonDBTM {
                   );
             }
             $migration->addField("glpi_plugin_sccm_configs", "is_password_sodium_encrypted", "tinyint(1) NOT NULL default '1'");
+            $migration->migrationOneTable('glpi_plugin_sccm_configs');
+         }
+
+         if (!$DB->fieldExists($table, 'use_lasthwscan')) {
+            $migration->addField("glpi_plugin_sccm_configs", "use_lasthwscan", "tinyint(1) NOT NULL default '0'");
             $migration->migrationOneTable('glpi_plugin_sccm_configs');
          }
       }
@@ -234,6 +240,11 @@ class PluginSccmConfig extends CommonDBTM {
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__("Value for spécific authentication", "sccm")."</td><td>";
       echo Html::input('auth_info', ['value' => $config->getField('auth_info')]);
+      echo "</td></tr>\n";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>".__("Use LastHWScan as FusionInventory last inventory", "sccm")."</td><td>";
+      Dropdown::showYesNo("use_lasthwscan", $config->getField('use_lasthwscan'));
       echo "</td></tr>\n";
 
       $config->showFormButtons(['candel'=>false]);

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -577,13 +577,6 @@ class PluginSccmSccm {
       $PluginSccmConfig->getFromDB(1);
       $retcode = -1;
 
-      $plugin = new Plugin();
-      $is_fi_active = $plugin->isActivated("fusioninventory");
-
-      if (!$is_fi_active) {
-         Toolbox::logInFile('sccm', "Push WARNING - Can't execute push, fusioninventory plugin is disabled"."\n", true);
-      }
-
       if ($PluginSccmConfig->getField('active_sync') == 1) {
          if ($res) {
 
@@ -645,7 +638,7 @@ class PluginSccmSccm {
                      } else {
                         $task->addVolume(1);
 
-                        if ($is_fi_active && $PluginSccmConfig->getField('use_lasthwscan') == 1) {
+                        if ($PluginSccmConfig->getField('use_lasthwscan') == 1) {
                            $data = PluginFusioninventoryAgent::getByDeviceID($tab['CSD-MachineID']);
                            $pfInventoryComputerComputer = new PluginFusioninventoryInventoryComputerComputer();
                            $a_computerextend = $pfInventoryComputerComputer->hasAutomaticInventory($data['computers_id']);

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -555,10 +555,12 @@ class PluginSccmSccm {
       sdi.User_Name0 as \"SDI-UserName\",
       sd.SMSID0 as \"SD-UUID\",
       sd.SystemRole0 as \"SD-SystemRole\",
-      VrS.User_Name0 as \"VrS-UserName\"
+      VrS.User_Name0 as \"VrS-UserName\",
+      vWD.LastHWScan as \"vWD-LastScan\"
       FROM Computer_System_DATA csd
       LEFT JOIN Motherboard_DATA md ON csd.MachineID = md.MachineID
       LEFT JOIN Operating_System_DATA osd ON csd.MachineID = osd.MachineID
+      LEFT JOIN v_GS_WORKSTATION_STATUS vWD ON csd.MachineID = vWD.ResourceID
       LEFT JOIN PC_BIOS_DATA pbd ON csd.MachineID = pbd.MachineID
       LEFT JOIN System_DISC sdi ON csd.MachineID = sdi.ItemKey
       LEFT JOIN System_DATA sd ON csd.MachineID = sd.MachineID
@@ -574,6 +576,13 @@ class PluginSccmSccm {
       $PluginSccmConfig = new PluginSccmConfig();
       $PluginSccmConfig->getFromDB(1);
       $retcode = -1;
+
+      $plugin = new Plugin();
+      $is_fi_active = $plugin->isActivated("fusioninventory");
+
+      if (!$is_fi_active) {
+         Toolbox::logInFile('sccm', "Push WARNING - Can't execute push, fusioninventory plugin is disabled"."\n", true);
+      }
 
       if ($PluginSccmConfig->getField('active_sync') == 1) {
          if ($res) {
@@ -635,6 +644,16 @@ class PluginSccmSccm {
                         Toolbox::logInFile('sccm', "ERROR RETURNED : ".$body." \n", true);
                      } else {
                         $task->addVolume(1);
+
+                        if ($is_fi_active && $PluginSccmConfig->getField('use_lasthwscan') == 1) {
+                           $data = PluginFusioninventoryAgent::getByDeviceID($tab['CSD-MachineID']);
+                           $pfInventoryComputerComputer = new PluginFusioninventoryInventoryComputerComputer();
+                           $a_computerextend = $pfInventoryComputerComputer->hasAutomaticInventory($data['computers_id']);
+                           if (count($a_computerextend) > 0) {
+                              $a_computerextend['last_fusioninventory_update'] = $tab['vWD-LastScan']->format('Y-m-d h:i');
+                              $pfInventoryComputerComputer->update($a_computerextend);
+                           }
+                        }
                         Toolbox::logInFile('sccm', "Push OK - ".$tab['CSD-MachineID']." \n", true);
                      }
 


### PR DESCRIPTION
### Changes description

Add new option to use SCCM last scan date as FusionInventory last inventory date

![image](https://user-images.githubusercontent.com/7335054/104468991-63b3c000-55b8-11eb-8e9e-5367edc5ca5e.png)



### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A