### PR TITLE
fix(config): fix accessibility if not logged or  not enough right

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -26,10 +26,8 @@
 include ('../../../inc/includes.php');
 require_once('../inc/config.class.php');
 
-Session::haveRight("config", UPDATE);
 
-Html::header(__("Setup - SCCM", "sccm"), $_SERVER["PHP_SELF"],
-             "plugins", "sccm", "configuration");
+Session::checkRight("config", UPDATE);
 
 $PluginSccmConfig = new PluginSccmConfig();
 
@@ -47,6 +45,7 @@ if (isset($_POST["update"])) {
    Html::back();
 }
 
+Html::header(__("Setup - SCCM", "sccm"), $_SERVER["PHP_SELF"],
+             "plugins", "sccm", "configuration");
 $PluginSccmConfig->showConfigForm($PluginSccmConfig);
-
 Html::footer();


### PR DESCRIPTION
### Changes description

The configuration page is displayed (read only mode) if the user is not logged in or if there is not enough right

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A