### PR TITLE
MECM database schema update

### DIFF
--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -360,8 +360,8 @@ XML;
       $CONTENT    = $this->sxml->CONTENT[0];
       $i = 0;
       foreach ($PluginSccmSccm->getStorages($this->device_id) as $value) {
-         $value['gld-TotalSize'] *= 1024;
-         $value['gld-FreeSpace'] *= 1024;
+         $value['gld-TotalSize'] = intval($value['gld-TotalSize'])*1024;
+         $value['gld-FreeSpace'] = intval($value['gld-FreeSpace'])*1024;
          $CONTENT->addChild('DRIVES');
          $DRIVES = $this->sxml->CONTENT[0]->DRIVES[$i];
          $DRIVES->addChild('DESCRIPTION', $value['gld-Description']);


### PR DESCRIPTION
gld-FreeSpace and gld-FreeSpace are now strings (bigint in schema, mssql driver converts it to string for php).  To multiply them, you have to convert to int 
Dont know if this happened in MECM 2203 or 2207