### PR TITLE
fix(xml): handle ip format

### DIFF
--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -342,7 +342,16 @@ XML;
             $CONTENT->addChild('NETWORKS');
             $NETWORKS = $this->sxml->CONTENT[0]->NETWORKS[$i];
 
-            $NETWORKS->addChild('IPADDRESS', $value['ND-IpAddress']);
+            //SCCM database store each IP format in one row, we need to split it
+            //and add each IP in dedicated XML node
+            $parts = explode(",", $value['ND-IpAddress']);
+            foreach ($parts as $ip) {
+               if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
+                  $NETWORKS->addChild('IPADDRESS', $ip);
+               } else {
+                  $NETWORKS->addChild('IPADDRESS6', $ip);
+               }
+            }
             $NETWORKS->addChild('DESCRIPTION', $value['ND-Name']);
             $NETWORKS->addChild('IPMASK', $value['ND-IpSubnet']);
             $NETWORKS->addChild('IPDHCP', $value['ND-DHCPServer']);

--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -346,10 +346,10 @@ XML;
             //and add each IP in dedicated XML node
             $parts = explode(",", $value['ND-IpAddress']);
             foreach ($parts as $ip) {
-               if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
-                  $NETWORKS->addChild('IPADDRESS', $ip);
+               if(filter_var(trim($ip), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
+                  $NETWORKS->addChild('IPADDRESS', trim($ip));
                } else {
-                  $NETWORKS->addChild('IPADDRESS6', $ip);
+                  $NETWORKS->addChild('IPADDRESS6', trim($ip));
                }
             }
             $NETWORKS->addChild('DESCRIPTION', $value['ND-Name']);


### PR DESCRIPTION
In my SCCM database the field "ND-IpAddress" contains IPv4 and IPv6 separatted by comma

![image](https://user-images.githubusercontent.com/7335054/229781089-0c79e6a2-0233-4423-903a-1b22d2c5dba4.png)

This allows both formats to be handled correctly