### PR TITLE
Remove invalid and unused TOKEN from generated XMLs

### DIFF
--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -57,7 +57,6 @@ class PluginSccmSccmxml {
       <VERSIONCLIENT>{$this->agentbuildnumber}</VERSIONCLIENT>
    </CONTENT>
    <DEVICEID>{$this->device_id}</DEVICEID>
-   <TOKEN>SOC_{$this->device_id}</TOKEN>
    <QUERY>INVENTORY</QUERY>
    <PROLOG></PROLOG>
 </REQUEST>


### PR DESCRIPTION
`TOKEN` was used to fill the `glpi_plugin_fusioninventory_agents.token` information, but there is no such field in GLPI native inventory `Agent` and sending it triggers following error:
```
JSON does not validate. Violations:
Additional properties not allowed: token
```

As this information is already contained in `DEVICEID`, it does not seems usefull, so I propose to remove it.