### PR TITLE
Handle empty DisplayName property for softwares

### DIFF
--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -216,7 +216,7 @@ XML;
             $value['ArPd-Publisher'] = preg_replace("#&#", "&amp;", $value['ArPd-Publisher']);
          }
 
-         $SOFTWARES->addChild('NAME', $value['ArPd-DisplayName']);
+         $SOFTWARES->addChild('NAME', $value['ArPd-DisplayName'] ?: NOT_AVAILABLE);
 
          if (isset($value['ArPd-Version'])) {
             $SOFTWARES->addChild('VERSION', $value['ArPd-Version']);


### PR DESCRIPTION
`DisplayName` is sometimes empty, and plugin sends an empty `<NAME></NAME>` or `<NAME />` to GLPI inventory. This is refused and following error is trigerred:
```
JSON does not validate. Violations: Required property missing: name, data: {"version":"13.1.4001.0","publisher":"Microsoft Corporation","install_date":"2017-03-14"} at #->properties:content->properties:softwares->items[1]:1 
```

I propose to use the `NOT_AVAILABLE` constant value in such case.