### PR TITLE
fix(inventory): remove useless <domain> property

### DIFF
--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -354,7 +354,7 @@ XML;
                $NETWORKS->addChild('IPDHCP', $value['ND-DHCPServer']);
                $NETWORKS->addChild('IPGATEWAY', $value['ND-IpGateway']);
                $NETWORKS->addChild('MACADDR', $value['ND-MacAddress']);
-               $NETWORKS->addChild('DOMAIN', $value['ND-DomainName']);
+
                $i++;
             }
          }


### PR DESCRIPTION
Prevent error about 

```
JSON does not validate. Violations:
Additional properties not allowed: domain at #->properties:content->properties:networks->items[0]:0
```  

```<DOMAIN>``` node is not allowed from GLPI ```inventory_format```

https://github.com/glpi-project/inventory_format/blob/7f691aa38eb5c890506e47bcf5ce46a0a896e6b0/inventory.schema.json#L1161

