### PR TITLE
Support multiple configurations

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -72,13 +72,13 @@ if (isset($_POST["add"])) {
 }
 
 Html::header(__("Setup - SCCM", "sccm"), $_SERVER["PHP_SELF"],
-             "plugins", "sccm", "configuration");
+             "config", "sccm", "configuration");
 $configId = isset($_GET['id']) ? intval($_GET['id']) : null;
 
 if ($configId !== null) {
    $PluginSccmConfig->showConfigForm($PluginSccmConfig, $configId);
 } else {
-   $PluginSccmConfig->showConfigList($PluginSccmConfig);
+   Search::show('PluginSccmConfig');
 }
 
 Html::footer();

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -61,13 +61,23 @@ class PluginSccmConfig extends CommonDBTM {
 
       if (!isset(self::$_instance)) {
          self::$_instance = new self();
-         if (!self::$_instance->getFromDB(1)) {
-            self::$_instance->getEmpty();
-         }
       }
       return self::$_instance;
    }
 
+   function getAllConfigurations() {
+      return getAllDataFromTable(self::getTable());
+   }
+
+   function loadFirstConfiguration() {
+      $configurations = $this->getAllConfigurations();
+      if (empty($configurations)) {
+         return false;
+      }
+      $this->getFromDB(array_values($configurations)[0]['id']);
+      
+      return true;
+   }
 
    function prepareInputForUpdate($input) {
       if (isset($input["sccmdb_password"]) AND !empty($input["sccmdb_password"])) {
@@ -81,6 +91,28 @@ class PluginSccmConfig extends CommonDBTM {
       return $input;
    }
 
+   function prepareInputForAdd($input) {
+      if (isset($input["sccmdb_password"]) AND !empty($input["sccmdb_password"])) {
+         $input["sccmdb_password"] = (new GLPIKey())->encrypt($input["sccmdb_password"]);
+      }
+
+      if (array_key_exists('inventory_server_url', $input) && !empty($input['inventory_server_url'])) {
+          $input['inventory_server_url'] = trim($input['inventory_server_url'], '/ ');
+      }
+
+      return $input;
+   }
+
+   static function isIdAutoIncrement()
+   {
+      global $DB;
+
+      $columns = $DB->query("SHOW COLUMNS FROM glpi_plugin_sccm_configs WHERE FIELD = 'id'");
+      $data = $columns->fetch_assoc();
+      Toolbox::logInFile('sccm', "Auto increment ... " . $data["Extra"] . " \n", true);
+      return str_contains($data["Extra"], "auto_increment");
+   }
+
    static function install(Migration $migration) {
       global $CFG_GLPI, $DB;
 
@@ -89,15 +121,20 @@ class PluginSccmConfig extends CommonDBTM {
       $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
       $table = 'glpi_plugin_sccm_configs';
+      Toolbox::logInFile('sccm', "Installing ...\n", true);
 
       if (!$DB->tableExists($table)) {
 
+         Toolbox::logInFile('sccm', "Table not exists, creating ...\n", true);
+
          $query = "CREATE TABLE `". $table."`(
-                     `id` int {$default_key_sign} NOT NULL,
+                     `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+                     `sccm_config_name` VARCHAR(255) NULL,                     
                      `sccmdb_host` VARCHAR(255) NULL,
                      `sccmdb_dbname` VARCHAR(255) NULL,
                      `sccmdb_user` VARCHAR(255) NULL,
                      `sccmdb_password` VARCHAR(255) NULL,
+                     `sccm_collection_name` VARCHAR(255) NULL,
                      `inventory_server_url` VARCHAR(255) NULL,
                      `active_sync` tinyint NOT NULL default '0',
                      `verify_ssl_cert` tinyint NOT NULL default '0',
@@ -116,15 +153,30 @@ class PluginSccmConfig extends CommonDBTM {
                               . "<br />".$DB->error());
 
          $query = "INSERT INTO `$table`
-                         (id, date_mod, sccmdb_host, sccmdb_dbname,
+                        (date_mod, sccmdb_host, sccmdb_dbname,
                            sccmdb_user, sccmdb_password, inventory_server_url)
-                   VALUES (1, NOW(), 'srv_sccm','bdd_sccm','user_sccm','',
+                  VALUES (NOW(), 'srv_sccm','bdd_sccm','user_sccm','',
                            NULL)";
-
-         $DB->queryOrDie($query, __("Error when using glpi_plugin_sccm_configs table.", "sccm")
-                                 . "<br />" . $DB->error());
+     
+            $DB->queryOrDie($query, __("Error when using glpi_plugin_sccm_configs table.", "sccm")
+                                    . "<br />" . $DB->error());
 
       } else {
+         if (!self::isIdAutoIncrement())
+         {
+            Toolbox::logInFile('sccm', "Cambiando a Auto increment ... \n", true);
+            $migration->changeField("glpi_plugin_sccm_configs", "id", "id", "autoincrement");
+            $migration->migrationOneTable('glpi_plugin_sccm_configs');            
+         }
+         if (!$DB->fieldExists($table, 'sccm_config_name')) {
+            $migration->addField("glpi_plugin_sccm_configs", "sccm_config_name", "VARCHAR(255)");
+            $migration->migrationOneTable('glpi_plugin_sccm_configs');
+         } 
+
+         if (!$DB->fieldExists($table, 'sccm_collection_name')) {
+            $migration->addField("glpi_plugin_sccm_configs", "sccm_collection_name", "VARCHAR(255)");
+            $migration->migrationOneTable('glpi_plugin_sccm_configs');
+         }         
 
          if (!$DB->fieldExists($table, 'verify_ssl_cert')) {
             $migration->addField("glpi_plugin_sccm_configs", "verify_ssl_cert", "tinyint NOT NULL default '0'");
@@ -153,24 +205,28 @@ class PluginSccmConfig extends CommonDBTM {
 
          if (!$DB->fieldExists($table, 'is_password_sodium_encrypted')) {
             $config = self::getInstance();
-            if (!empty($config->fields['sccmdb_password'])) {
-               $key = new GLPIKey();
-               $migration->addPostQuery(
-                  $DB->buildUpdate(
-                     'glpi_plugin_sccm_configs',
-                     [
-                        'sccmdb_password' => $key->encrypt(
-                           $key->decryptUsingLegacyKey(
-                              $config->fields['sccmdb_password']
+            $configurations = $config->getAllConfigurations();
+            foreach ($configurations as $data) {
+               $config->getFromDB($data['id']);
+               if (!empty($config->fields['sccmdb_password'])) {
+                  $key = new GLPIKey();
+                  $migration->addPostQuery(
+                     $DB->buildUpdate(
+                        'glpi_plugin_sccm_configs',
+                        [
+                           'sccmdb_password' => $key->encrypt(
+                              $key->decryptUsingLegacyKey(
+                                 $config->fields['sccmdb_password']
+                              )
                            )
+                        ],
+                        [
+                           'id' => $data['id'],
+                        ]
                         )
-                     ],
-                     [
-                        'id' => 1,
-                     ]
-                     )
-                  );
-            }
+                     );
+               }   
+            }            
             $migration->addField("glpi_plugin_sccm_configs", "is_password_sodium_encrypted", "tinyint NOT NULL default '1'");
             $migration->migrationOneTable('glpi_plugin_sccm_configs');
          }
@@ -219,6 +275,7 @@ class PluginSccmConfig extends CommonDBTM {
    static function uninstall() {
       global $DB;
 
+      Toolbox::logInFile('sccm', "Uninstalling ...\n", true);
       if ($DB->tableExists('glpi_plugin_sccm_configs')) {
 
          $query = "DROP TABLE `glpi_plugin_sccm_configs`";
@@ -227,13 +284,42 @@ class PluginSccmConfig extends CommonDBTM {
       return true;
    }
 
+   static function configUrl() {      
+      global $CFG_GLPI;
+      return $CFG_GLPI['url_base'] . "/plugins/sccm/front/config.form.php";;
+   }
 
-   static function showConfigForm($item) {
+   static function showConfigList() {
+      global $DB;
+
+      $configUrl = self::configUrl();
+
+      echo "<p>SCCM Configuration list: </p>";
+      echo "<ul>";
+
+      $configs = $DB->query("select * from glpi_plugin_sccm_configs");
+      while ($data = $configs->fetch_assoc()) {
+         echo "   <li> <a href='" . $configUrl . "?id=" . $data['id'] . "'>".$data['sccm_config_name']."</a>";
+      }
+      echo "   <li> <a href='" . $configUrl . "?id=-1'>Add new ...</a>";
+      echo "</ul>";
+   }
+
+   static function showConfigForm($item, $configId) {
       global $CFG_GLPI;
 
       $config = self::getInstance();
 
+      if (!$config->getFromDB($configId)) {
+         $config->getEmpty();
+      }      
+
       $config->showFormHeader();
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>".__("SCCM configuration name", "sccm")." (Id: ".$config->getField('id').")</td><td>";
+      echo Html::input('sccm_config_name', ['value' => $config->getField('sccm_config_name')]);
+      echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__("Enable SCCM synchronization", "sccm")."</td><td>";
@@ -260,6 +346,11 @@ class PluginSccmConfig extends CommonDBTM {
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__("Password", "sccm")."</td><td>";
       echo "<input type='password' name='sccmdb_password' value='$password' autocomplete='off'>";
+      echo "</td></tr>\n";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>".__("SCCM collection name", "sccm")."</td><td>";
+      echo Html::input('sccm_collection_name', ['value' => $config->getField('sccm_collection_name')]);
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -65,6 +65,66 @@ class PluginSccmConfig extends CommonDBTM {
       return self::$_instance;
    }
 
+   public function rawSearchOptions()
+   {
+      $tab = [];
+      $tab[] = [
+         'id'                 => 'common',
+         'name'               => self::getTypeName(2)
+      ];
+
+      $tab[] = [
+         'id'                 => '1',
+         'table'              => $this->getTable(),
+         'field'              => 'sccm_config_name',
+         'name'               => __('Config name'),
+         'massiveaction'      => false,
+         'datatype'           => 'itemlink'
+      ];
+
+      $tab[] = [
+         'id'                 => '2',
+         'table'              => $this->getTable(),
+         'field'              => 'active_sync',
+         'name'               => __('Enabled'),
+         'massiveaction'      => false,
+         'datatype'           => 'bool'
+      ];
+      $tab[] = [
+         'id'                 => '3',
+         'table'              => $this->getTable(),
+         'field'              => 'sccm_collection_name',
+         'name'               => __('Collection'),
+         'massiveaction'      => false,
+         'datatype'           => 'string'
+      ];
+      $tab[] = [
+         'id'                 => '4',
+         'table'              => $this->getTable(),
+         'field'              => 'sccmdb_host',
+         'name'               => __('Db Host'),
+         'massiveaction'      => false,
+         'datatype'           => 'string'
+      ];
+      $tab[] = [
+         'id'                 => '5',
+         'table'              => $this->getTable(),
+         'field'              => 'sccmdb_dbname',
+         'name'               => __('DB Name'),
+         'massiveaction'      => false,
+         'datatype'           => 'string'
+      ];
+      $tab[] = [
+         'id'                 => '6',
+         'table'              => $this->getTable(),
+         'field'              => 'sccmdb_user',
+         'name'               => __('DB User'),
+         'massiveaction'      => false,
+         'datatype'           => 'string'
+      ];
+      return $tab;
+   }
+
    function getAllConfigurations() {
       return getAllDataFromTable(self::getTable());
    }

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -39,6 +39,12 @@ class PluginSccmSccm {
 
    var $devices;
 
+   public PluginSccmSccmdb $sccmdb;
+
+   public function __construct(PluginSccmSccmdb $sccmdb) {
+      $this->sccmdb = $sccmdb;
+   }
+
    static function getTypeName($nb = 0) {
       return __('SCCM', 'sccm');
    }
@@ -47,15 +53,11 @@ class PluginSccmSccm {
       echo __('Please, read the documentation before using that.', 'footprints');
    }
 
-   function getDevices($where = 0, $limit = 99999999) {
+   function getDevices($collection_name, $where = 0, $limit = 99999999) {
 
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
-      $query = self::getcomputerQuery();
+      $query = self::getcomputerQuery($collection_name);
 
       if ($where!=0) {
          $query.= " WHERE csd.MachineID = '" . $where . "'";
@@ -74,17 +76,11 @@ class PluginSccmSccm {
 
          $i++;
       }
-
-      $PluginSccmSccmdb->disconnect();
    }
 
    function getDatas($type, $deviceid, $limit = 99999999) {
 
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
       $datas = [];
 
@@ -116,18 +112,12 @@ class PluginSccmSccm {
          $i++;
       }
 
-      $PluginSccmSccmdb->disconnect();
-
       return $data;
    }
 
    function getNetwork($deviceid, $limit = 99999999) {
 
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
       $query = "SELECT NeDa.IPAddress00 as \"ND-IpAddress\",
       NeDa.MACAddress00 as \"ND-MacAddress\",
@@ -159,18 +149,12 @@ class PluginSccmSccm {
          $i++;
       }
 
-      $PluginSccmSccmdb->disconnect();
-
       return $data;
    }
 
    function getSoftware($deviceid, $limit = 99999999) {
 
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
       $query = "SELECT ArPd_64.DisplayName0 as \"ArPd-DisplayName\",
       ArPd_64.InstallDate0 as \"ArPd-InstallDate\",
@@ -205,18 +189,12 @@ class PluginSccmSccm {
          $i++;
       }
 
-      $PluginSccmSccmdb->disconnect();
-
       return $data;
    }
 
    function getMemories($deviceid, $limit = 99999999) {
 
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
       $query = "SELECT
             Capacity0 as \"Mem-Capacity\",
@@ -253,20 +231,14 @@ class PluginSccmSccm {
          $i++;
       }
 
-      $PluginSccmSccmdb->disconnect();
-
       return $data;
    }
 
    function getVideos($deviceid, $limit = 99999999) {
 
-        $PluginSccmSccmdb = new PluginSccmSccmdb();
-        $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
-        $query = "
+      $query = "
       SELECT
          VideoProcessor0 as \"Vid-Chipset\",
          AdapterRAM0/1024 as \"Vid-Memory\",
@@ -295,18 +267,12 @@ class PluginSccmSccm {
          $i++;
       }
 
-        $PluginSccmSccmdb->disconnect();
-
-        return $data;
+      return $data;
    }
 
    function getSounds($deviceid, $limit = 99999999) {
 
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
       $query = "
       SELECT distinct
@@ -333,18 +299,12 @@ class PluginSccmSccm {
          $i++;
       }
 
-      $PluginSccmSccmdb->disconnect();
-
       return $data;
    }
 
    function getStorages($deviceid, $limit = 99999999) {
 
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
       $query = "
       SELECT
@@ -380,18 +340,12 @@ class PluginSccmSccm {
          $i++;
       }
 
-      $PluginSccmSccmdb->disconnect();
-
       return $data;
    }
 
    function getMedias($deviceid, $limit = 99999999) {
 
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      if (!$res) {
-         die;
-      }
+      $PluginSccmSccmdb = $this->sccmdb;
 
       $query = "
       SELECT distinct
@@ -420,8 +374,6 @@ class PluginSccmSccm {
 
          $i++;
       }
-
-      $PluginSccmSccmdb->disconnect();
 
       return $data;
    }
@@ -473,123 +425,183 @@ class PluginSccmSccm {
       ini_set('max_execution_time', 0);
       $retcode = -1;
 
-      $REP_XML = GLPI_PLUGIN_DOC_DIR.'/sccm/xml/';
-
       $PluginSccmConfig = new PluginSccmConfig();
-      $PluginSccmConfig->getFromDB(1);
+      $configurations = $PluginSccmConfig->getAllConfigurations();
 
-      $PluginSccmSccm = new PluginSccmSccm();
+      if (empty($configurations))
+      {
+         echo __("No SCCM configurations found.", "sccm");
+         return $retcode;
+      }
 
-      if ($PluginSccmConfig->getField('active_sync') == 1) {
+      foreach ($configurations as $config) {
 
-         $PluginSccmSccm->getDevices();
-         Toolbox::logInFile('sccm', "getDevices OK \n", true);
+         $configId = $config['id'];
+         Toolbox::logInFile('sccm', "Init Collect on ". $config['sccm_config_name'] ." \n", true);
 
-         Toolbox::logInFile('sccm', "Generate XML start : "
-            . count($PluginSccmSccm->devices) . " files\n", true);
+         $PluginSccmConfig->getFromDB($configId);
 
-         foreach ($PluginSccmSccm->devices as $device_values) {
+         $REP_XML = GLPI_PLUGIN_DOC_DIR.'/sccm/xml/'. $PluginSccmConfig->getField('id');
 
-            $PluginSccmSccmxml = new PluginSccmSccmxml($device_values);
+         if (!is_dir($REP_XML)) {
+            mkdir($REP_XML);
+         }   
 
-            $PluginSccmSccmxml->setAccessLog();
-            $PluginSccmSccmxml->setAccountInfos();
-            $PluginSccmSccmxml->setHardware();
-            $PluginSccmSccmxml->setOS();
-            $PluginSccmSccmxml->setBios();
-            $PluginSccmSccmxml->setProcessors();
-            $PluginSccmSccmxml->setSoftwares();
-            $PluginSccmSccmxml->setMemories();
-            $PluginSccmSccmxml->setVideos();
-            $PluginSccmSccmxml->setSounds();
-            $PluginSccmSccmxml->setUsers();
-            $PluginSccmSccmxml->setNetworks();
-            $PluginSccmSccmxml->setStorages();
+         if ($PluginSccmConfig->getField('active_sync') == 1) {
+            $PluginSccmSccmdb = new PluginSccmSccmdb();                  
+            if (!$PluginSccmSccmdb->connect($config['id'])) {
+               Toolbox::logInFile('sccm', "Error connecting to database on config ". $config['sccm_config_name'] ." \n", true);
+               continue;
+            }
+            $PluginSccmSccm = new PluginSccmSccm($PluginSccmSccmdb);
 
-            $SXML = $PluginSccmSccmxml->sxml;
+            Toolbox::logInFile('sccm', "Getting devices ... \n", true);
+            $PluginSccmSccm->getDevices($PluginSccmConfig->getField('sccm_collection_name'));
+            Toolbox::logInFile('sccm', "getDevices OK \n", true);
 
-            $SXML->asXML($REP_XML.$PluginSccmSccmxml->device_id.".ocs");
+            if ($PluginSccmSccm->devices == null){
+               Toolbox::logInFile('sccm', "Collect completed, no devices found.\n", true);
+               continue;
+            }
 
-            Toolbox::logInFile('sccm', "Collect OK for device - ".$PluginSccmSccmxml->device_id." \n", true);
-            $task->addVolume(1);
+            Toolbox::logInFile('sccm', "Generate XML start : "
+               . count($PluginSccmSccm->devices) . " files\n", true);
+
+            foreach ($PluginSccmSccm->devices as $device_values) {
+
+               $PluginSccmSccmxml = new PluginSccmSccmxml($PluginSccmSccm, $device_values);
+
+               $PluginSccmSccmxml->setAccessLog();
+               $PluginSccmSccmxml->setAccountInfos();
+               $PluginSccmSccmxml->setHardware();
+               $PluginSccmSccmxml->setOS();
+               $PluginSccmSccmxml->setBios();
+               $PluginSccmSccmxml->setProcessors();
+               $PluginSccmSccmxml->setSoftwares();
+               $PluginSccmSccmxml->setMemories();
+               $PluginSccmSccmxml->setVideos();
+               $PluginSccmSccmxml->setSounds();
+               $PluginSccmSccmxml->setUsers();
+               $PluginSccmSccmxml->setNetworks();
+               $PluginSccmSccmxml->setStorages();
+
+               $SXML = $PluginSccmSccmxml->sxml;
+
+               $SXML->asXML($REP_XML."/".$PluginSccmSccmxml->device_id.".ocs");
+
+               Toolbox::logInFile('sccm', "Collect OK for device - ".$PluginSccmSccmxml->device_id." \n", true);
+               $task->addVolume(1);
+            }
+            $retcode = 1;
+            Toolbox::logInFile('sccm', "Collect completed on ". $config['sccm_config_name'] .", " . count($PluginSccmSccm->devices) . " devices found \n", true);
+            $PluginSccmSccmdb->disconnect();
+
+         } else {
+            Toolbox::logInFile('sccm', "Collect is disabled by configuration on ". $config['sccm_config_name']." \n", true);
+            echo __("Collect is disabled by configuration on ". $config['sccm_config_name'] .".", "sccm");
          }
-         $retcode = 1;
-         Toolbox::logInFile('sccm', "Collect completed \n", true);
-
-      } else {
-         echo __("Collect is disabled by configuration.", "sccm");
       }
 
       return $retcode;
    }
 
-   static function getcomputerQuery() {
-      return "SELECT csd.Description00 as \"CSD-Description\",
-      csd.Domain00 as \"CSD-Domain\",
-      csd.Manufacturer00 as \"CSD-Manufacturer\",
-      csd.Model00 as \"CSD-Model\",
-      csd.Roles00 as \"CSD-Roles\",
-      csd.SystemType00 as \"CSD-SystemType\",
-      csd.UserName00 as \"CSD-UserName\",
-      csd.MachineID as \"CSD-MachineID\",
-      csd.TimeKey as \"CSD-TimeKey\",
-      md.SystemName00 as \"MD-SystemName\",
-      osd.BuildNumber00 as \"OSD-BuildNumber\",
-      osd.Caption00 as \"OSD-Caption\",
-      osd.CSDVersion00 as \"OSD-CSDVersion\",
-      osd.BootDevice00 as \"OSD-BootDevice\",
-      osd.InstallDate00 as \"OSD-InstallDate\",
-      osd.LastBootUpTime00 as \"OSD-LastBootUpTime\",
-      osd.Manufacturer00 as \"OSD-Manufacturer\",
-      osd.Name00 as \"OSD-Name\",
-      osd.Organization00 as \"OSD-Organization\",
-      osd.RegisteredUser00 as \"OSD-RegisteredUser\",
-      osd.TotalVirtualMemorySize00 as \"OSD-TotalVirtualMemory\",
-      osd.TotalVisibleMemorySize00 as \"OSD-TotalVisibleMemory\",
-      osd.Version00 as \"OSD-Version\",
-      pbd.SerialNumber00 as \"PBD-SerialNumber\",
-      pbd.ReleaseDate00 as \"PBD-ReleaseDate\",
-      pbd.Name00 as \"PBD-Name\",
-      pbd.SMBIOSBIOSVersion00 as \"PBD-BiosVersion\",
-      pbd.Version00 as \"PBD-Version\",
-      pbd.Manufacturer00 as \"PBD-Manufacturer\",
-      sdi.User_Name0 as \"SDI-UserName\",
-      sd.SMSID0 as \"SD-UUID\",
-      sd.SystemRole0 as \"SD-SystemRole\",
-      VrS.User_Name0 as \"VrS-UserName\",
-      vWD.LastHWScan as \"vWD-LastScan\"
-      FROM Computer_System_DATA csd
-      LEFT JOIN Motherboard_DATA md ON csd.MachineID = md.MachineID
-      LEFT JOIN Operating_System_DATA osd ON csd.MachineID = osd.MachineID
-      LEFT JOIN v_GS_WORKSTATION_STATUS vWD ON csd.MachineID = vWD.ResourceID
-      LEFT JOIN PC_BIOS_DATA pbd ON csd.MachineID = pbd.MachineID
-      LEFT JOIN System_DISC sdi ON csd.MachineID = sdi.ItemKey
-      LEFT JOIN System_DATA sd ON csd.MachineID = sd.MachineID
-      INNER JOIN v_R_System VrS ON csd.MachineID = VrS.ResourceID
-      WHERE csd.MachineID is not null and csd.MachineID != ''";
+   static function getcomputerQuery($collection_name) {
+
+      $result = "SELECT csd.Description00 as \"CSD-Description\",
+         csd.Domain00 as \"CSD-Domain\",
+         csd.Manufacturer00 as \"CSD-Manufacturer\",
+         csd.Model00 as \"CSD-Model\",
+         csd.Roles00 as \"CSD-Roles\",
+         csd.SystemType00 as \"CSD-SystemType\",
+         csd.UserName00 as \"CSD-UserName\",
+         csd.MachineID as \"CSD-MachineID\",
+         csd.TimeKey as \"CSD-TimeKey\",
+         md.SystemName00 as \"MD-SystemName\",
+         osd.BuildNumber00 as \"OSD-BuildNumber\",
+         osd.Caption00 as \"OSD-Caption\",
+         osd.CSDVersion00 as \"OSD-CSDVersion\",
+         osd.BootDevice00 as \"OSD-BootDevice\",
+         osd.InstallDate00 as \"OSD-InstallDate\",
+         osd.LastBootUpTime00 as \"OSD-LastBootUpTime\",
+         osd.Manufacturer00 as \"OSD-Manufacturer\",
+         osd.Name00 as \"OSD-Name\",
+         osd.Organization00 as \"OSD-Organization\",
+         osd.RegisteredUser00 as \"OSD-RegisteredUser\",
+         osd.TotalVirtualMemorySize00 as \"OSD-TotalVirtualMemory\",
+         osd.TotalVisibleMemorySize00 as \"OSD-TotalVisibleMemory\",
+         osd.Version00 as \"OSD-Version\",
+         pbd.SerialNumber00 as \"PBD-SerialNumber\",
+         pbd.ReleaseDate00 as \"PBD-ReleaseDate\",
+         pbd.Name00 as \"PBD-Name\",
+         pbd.SMBIOSBIOSVersion00 as \"PBD-BiosVersion\",
+         pbd.Version00 as \"PBD-Version\",
+         pbd.Manufacturer00 as \"PBD-Manufacturer\",
+         sdi.User_Name0 as \"SDI-UserName\",
+         sd.SMSID0 as \"SD-UUID\",
+         sd.SystemRole0 as \"SD-SystemRole\",
+         VrS.User_Name0 as \"VrS-UserName\",
+         vWD.LastHWScan as \"vWD-LastScan\"
+         FROM Computer_System_DATA csd
+         LEFT JOIN Motherboard_DATA md ON csd.MachineID = md.MachineID
+         LEFT JOIN Operating_System_DATA osd ON csd.MachineID = osd.MachineID
+         LEFT JOIN v_GS_WORKSTATION_STATUS vWD ON csd.MachineID = vWD.ResourceID
+         LEFT JOIN PC_BIOS_DATA pbd ON csd.MachineID = pbd.MachineID
+         LEFT JOIN System_DISC sdi ON csd.MachineID = sdi.ItemKey
+         LEFT JOIN System_DATA sd ON csd.MachineID = sd.MachineID
+         INNER JOIN v_R_System VrS ON csd.MachineID = VrS.ResourceID
+         WHERE csd.MachineID is not null and csd.MachineID != ''
+      ";
+
+      if (!empty($collection_name))
+      {
+         $result .= "    AND md.SystemName00 in (
+            SELECT FCM.Name
+            FROM v_FullCollectionMembership FCM INNER JOIN v_Collection COL
+              ON FCM.CollectionID = COL.CollectionID
+            WHERE col.name='" . $collection_name . "'
+          )
+         ";
+      }
+
+      return $result;
    }
 
 
    static function executePush($task) {
       global $CFG_GLPI;
-
-      $PluginSccmSccmdb = new PluginSccmSccmdb();
-      $res = $PluginSccmSccmdb->connect();
-      $PluginSccmConfig = new PluginSccmConfig();
-      $PluginSccmConfig->getFromDB(1);
       $retcode = -1;
 
-      if ($PluginSccmConfig->getField('active_sync') == 1) {
-         if ($res) {
+      $PluginSccmConfig = new PluginSccmConfig();
+      $configurations = $PluginSccmConfig->getAllConfigurations();
 
-            $query = self::getcomputerQuery();
+      if (empty($configurations))
+      {
+         echo __("No SCCM configurations found.", "sccm");
+         return $retcode;
+      }
+
+      foreach ($configurations as $config) {
+
+         Toolbox::logInFile('sccm', "Init Push on ". $config['sccm_config_name'] ." \n", true);
+
+         $PluginSccmSccmdb = new PluginSccmSccmdb();
+         if (!$PluginSccmSccmdb->connect($config['id'])) {
+            Toolbox::logInFile('sccm', "Error connecting to database on config ". $config['sccm_config_name'] ." \n", true);
+            continue;
+         }
+
+         $PluginSccmConfig->getFromDB($config['id']);
+
+         if ($PluginSccmConfig->getField('active_sync') == 1) {
+
+            $query = self::getcomputerQuery($PluginSccmConfig->getField('sccm_collection_name'));
             $result = $PluginSccmSccmdb->exec_query($query);
 
             $tab = [];
 
             while ($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) {
 
-               $REP_XML = realpath(GLPI_PLUGIN_DOC_DIR.'/sccm/xml/'.$tab['CSD-MachineID'].'.ocs');
+               $REP_XML = realpath(GLPI_PLUGIN_DOC_DIR.'/sccm/xml/'. $PluginSccmConfig->getField('id')."/".$tab['CSD-MachineID'].'.ocs');
 
                if ($REP_XML === false) {
                   Toolbox::logInFile('sccm', "There is a problem with the path, realpath function return false.\nPath : ".$REP_XML."\n", true);
@@ -659,16 +671,16 @@ class PluginSccmSccm {
 
                   }
                   curl_close($ch);
-               } else {
+               } else {                     
                   Toolbox::logInFile('sccm', "Can't load the file with the path : ".$REP_XML."\n", true);
                }
             }
-            Toolbox::logInFile('sccm', "Push completed \n", true);
+            Toolbox::logInFile('sccm', "Push completed on ".$config['sccm_config_name']."\n", true);
             $PluginSccmSccmdb->disconnect();
-            $retcode = 1;
+            $retcode = 1;            
+         } else {
+            echo __("Push is disabled by configuration on ".$config['sccm_config_name'].".", "sccm");
          }
-      } else {
-         echo __("Push is disabled by configuration.", "sccm");
       }
 
       return $retcode;

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -672,7 +672,11 @@ class PluginSccmSccm {
                   }
                   curl_close($ch);
                } else {                     
-                  Toolbox::logInFile('sccm', "Can't load the file with the path : ".$REP_XML."\n", true);
+                  $errors = "";
+                     foreach(libxml_get_errors() as $error) {
+                        $errors = $errors . $error->message . "\n";
+                     }
+                     Toolbox::logInFile('sccm', "Can't load the file with the path : ".$REP_XML."\n\n".$errors."\n", true);                     
                }
             }
             Toolbox::logInFile('sccm', "Push completed on ".$config['sccm_config_name']."\n", true);

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -584,16 +584,16 @@ class PluginSccmSccm {
 
          Toolbox::logInFile('sccm', "Init Push on ". $config['sccm_config_name'] ." \n", true);
 
-         $PluginSccmSccmdb = new PluginSccmSccmdb();
-         if (!$PluginSccmSccmdb->connect($config['id'])) {
-            Toolbox::logInFile('sccm', "Error connecting to database on config ". $config['sccm_config_name'] ." \n", true);
-            continue;
-         }
-
-         $PluginSccmConfig->getFromDB($config['id']);
+         $PluginSccmConfig->getFromDB($config['id']);   
 
          if ($PluginSccmConfig->getField('active_sync') == 1) {
 
+            $PluginSccmSccmdb = new PluginSccmSccmdb();
+            if (!$PluginSccmSccmdb->connect($config['id'])) {
+               Toolbox::logInFile('sccm', "Error connecting to database on config ". $config['sccm_config_name'] ." \n", true);
+               continue;
+            }
+   
             $query = self::getcomputerQuery($PluginSccmConfig->getField('sccm_collection_name'));
             $result = $PluginSccmSccmdb->exec_query($query);
 
@@ -683,6 +683,7 @@ class PluginSccmSccm {
             $PluginSccmSccmdb->disconnect();
             $retcode = 1;            
          } else {
+            Toolbox::logInFile('sccm', "Collect is disabled by configuration on ". $config['sccm_config_name']." \n", true);
             echo __("Push is disabled by configuration on ".$config['sccm_config_name'].".", "sccm");
          }
       }

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -683,7 +683,7 @@ class PluginSccmSccm {
             $PluginSccmSccmdb->disconnect();
             $retcode = 1;            
          } else {
-            Toolbox::logInFile('sccm', "Collect is disabled by configuration on ". $config['sccm_config_name']." \n", true);
+            Toolbox::logInFile('sccm', "Push is disabled by configuration on ". $config['sccm_config_name']." \n", true);
             echo __("Push is disabled by configuration on ".$config['sccm_config_name'].".", "sccm");
          }
       }

--- a/inc/sccmdb.class.php
+++ b/inc/sccmdb.class.php
@@ -37,10 +37,21 @@ class PluginSccmSccmdb {
 
    var $dbconn;
 
-   function connect() {
+   function testConfiguration($id) {
+      if ($this->connect($id)) {
+         Toolbox::logInFile('sccm', "Success connecting to new configuration ".$_POST['sccm_config_name']." ...\n", true);
+         Session::addMessageAfterRedirect("Connexion réussie !.", false, INFO, false);
+         $this->disconnect();
+      } else {
+         Toolbox::logInFile('sccm', "Error connecting to new configuration ".$_POST['sccm_config_name']." ...\n", true);
+         Session::addMessageAfterRedirect("Connexion incorrecte.", false, ERROR, false);   
+      }   
+   }
+
+   function connect($id) {
 
       $PluginSccmConfig = new PluginSccmConfig();
-      $PluginSccmConfig->getFromDB(1);
+      $PluginSccmConfig->getFromDB($id);
 
       $host = $PluginSccmConfig->getField('sccmdb_host');
       $dbname = $PluginSccmConfig->getField('sccmdb_dbname');

--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -339,26 +339,28 @@ XML;
          $i = 0;
 
          foreach ($networks as $value) {
-            //SCCM database store each IP format in one row, we need to split it
-            //and add each IP in dedicated XML node
-            $parts = explode(",", $value['ND-IpAddress']);
-            foreach ($parts as $ip) {
-               $CONTENT->addChild('NETWORKS');
-               $NETWORKS = $this->sxml->CONTENT[0]->NETWORKS[$i];
+            if ($value['ND-IpAddress'] != null) {
+               //SCCM database store each IP format in one row, we need to split it
+               //and add each IP in dedicated XML node
+               $parts = explode(",", $value['ND-IpAddress']);
+               foreach ($parts as $ip) {
+                  $CONTENT->addChild('NETWORKS');
+                  $NETWORKS = $this->sxml->CONTENT[0]->NETWORKS[$i];
 
-               if(filter_var(trim($ip), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
-                  $NETWORKS->addChild('IPADDRESS', trim($ip));
-               } else {
-                  $NETWORKS->addChild('IPADDRESS6', trim($ip));                     
+                  if(filter_var(trim($ip), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
+                     $NETWORKS->addChild('IPADDRESS', trim($ip));
+                  } else {
+                     $NETWORKS->addChild('IPADDRESS6', trim($ip));                     
+                  }
+
+                  $NETWORKS->addChild('DESCRIPTION', $value['ND-Name']);
+                  $NETWORKS->addChild('IPMASK', $value['ND-IpSubnet']);
+                  $NETWORKS->addChild('IPDHCP', $value['ND-DHCPServer']);
+                  $NETWORKS->addChild('IPGATEWAY', $value['ND-IpGateway']);
+                  $NETWORKS->addChild('MACADDR', $value['ND-MacAddress']);
+
+                  $i++;
                }
-
-               $NETWORKS->addChild('DESCRIPTION', $value['ND-Name']);
-               $NETWORKS->addChild('IPMASK', $value['ND-IpSubnet']);
-               $NETWORKS->addChild('IPDHCP', $value['ND-DHCPServer']);
-               $NETWORKS->addChild('IPGATEWAY', $value['ND-IpGateway']);
-               $NETWORKS->addChild('MACADDR', $value['ND-MacAddress']);
-
-               $i++;
             }
          }
       }

--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -41,7 +41,11 @@ class PluginSccmSccmxml {
    var $agentbuildnumber;
    var $username;
 
-   function __construct($data) {
+   public PluginSccmSccm $sccm;
+
+   function __construct(PluginSccmSccm $sccm, $data) {
+
+      $this->sccm = $sccm;
 
       $plug = new Plugin();
       $plug->getFromDBbyDir("sccm");
@@ -172,12 +176,10 @@ XML;
 
    function setProcessors() {
 
-      $PluginSccmSccm = new PluginSccmSccm();
-
       $cpukeys = [];
 
       $CONTENT    = $this->sxml->CONTENT[0]; $i = 0;
-      foreach ($PluginSccmSccm->getDatas('processors', $this->device_id) as $value) {
+      foreach ($this->sccm->getDatas('processors', $this->device_id) as $value) {
          if (!in_array($value['CPUKey00'], $cpukeys)) {
             $CONTENT->addChild('CPUS');
             $CPUS = $this->sxml->CONTENT[0]->CPUS[$i];
@@ -198,11 +200,9 @@ XML;
 
    function setSoftwares() {
 
-      $PluginSccmSccm = new PluginSccmSccm();
-
       $antivirus = []; $inject_antivirus = false;
       $CONTENT    = $this->sxml->CONTENT[0]; $i = 0;
-      foreach ($PluginSccmSccm->getSoftware($this->device_id) as $value) {
+      foreach ($this->sccm->getSoftware($this->device_id) as $value) {
 
          $CONTENT->addChild('SOFTWARES');
          $SOFTWARES = $this->sxml->CONTENT[0]->SOFTWARES[$i];
@@ -212,7 +212,7 @@ XML;
          }
 
          if (isset($value['ArPd-Publisher']) && preg_match("#&#", $value['ArPd-Publisher'])) {
-            $value['ArPd-Publisher'] = preg_replace("#&#", "&amp;", $value['ArPd-Publisher']);
+            $value['ArPd-Publisher'] = preg_replace("#&#", "&amp;", $value['ArPd-Publisher']);            
          }
 
          $SOFTWARES->addChild('NAME', $value['ArPd-DisplayName'] ?: NOT_AVAILABLE);
@@ -245,11 +245,9 @@ XML;
       }
    }
 
-   function setMemories() {
-        $PluginSccmSccm = new PluginSccmSccm();
-
-        $CONTENT = $this->sxml->CONTENT[0]; $i = 0;
-      foreach ($PluginSccmSccm->getMemories($this->device_id) as $value) {
+   function setMemories() {        
+      $CONTENT = $this->sxml->CONTENT[0]; $i = 0;
+      foreach ($this->sccm->getMemories($this->device_id) as $value) {
 
          $CONTENT->addChild('MEMORIES');
          $MEMORIES = $this->sxml->CONTENT[0]->MEMORIES[$i];
@@ -272,10 +270,8 @@ XML;
    }
 
    function setVideos() {
-        $PluginSccmSccm = new PluginSccmSccm();
-
-        $CONTENT = $this->sxml->CONTENT[0]; $i = 0;
-      foreach ($PluginSccmSccm->getVideos($this->device_id) as $value) {
+      $CONTENT = $this->sxml->CONTENT[0]; $i = 0;
+      foreach ($this->sccm->getVideos($this->device_id) as $value) {
 
          $CONTENT->addChild('VIDEOS');
          $VIDEOS = $this->sxml->CONTENT[0]->VIDEOS[$i];
@@ -291,10 +287,8 @@ XML;
    }
 
    function setSounds() {
-      $PluginSccmSccm = new PluginSccmSccm();
-
       $CONTENT = $this->sxml->CONTENT[0]; $i = 0;
-      foreach ($PluginSccmSccm->getSounds($this->device_id) as $value) {
+      foreach ($this->sccm->getSounds($this->device_id) as $value) {
 
          $CONTENT->addChild('SOUNDS');
          $SOUNDS = $this->sxml->CONTENT[0]->SOUNDS[$i];
@@ -325,11 +319,9 @@ XML;
 
    function setNetworks() {
 
-      $PluginSccmSccm = new PluginSccmSccm();
-
       $CONTENT = $this->sxml->CONTENT[0];
 
-      $networks = $PluginSccmSccm->getNetwork($this->device_id);
+      $networks = $this->sccm->getNetwork($this->device_id);
 
       if (count($networks) > 0) {
 
@@ -346,7 +338,7 @@ XML;
                if(filter_var(trim($ip), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
                   $NETWORKS->addChild('IPADDRESS', trim($ip));
                } else {
-                  $NETWORKS->addChild('IPADDRESS6', trim($ip));
+                  $NETWORKS->addChild('IPADDRESS6', trim($ip));                     
                }
 
                $NETWORKS->addChild('DESCRIPTION', $value['ND-Name']);
@@ -362,10 +354,9 @@ XML;
    }
 
    function setStorages() {
-      $PluginSccmSccm = new PluginSccmSccm();
       $CONTENT    = $this->sxml->CONTENT[0];
       $i = 0;
-      foreach ($PluginSccmSccm->getStorages($this->device_id) as $value) {
+      foreach ($this->sccm->getStorages($this->device_id) as $value) {
          $value['gld-TotalSize'] = intval($value['gld-TotalSize'])*1024;
          $value['gld-FreeSpace'] = intval($value['gld-FreeSpace'])*1024;
          $CONTENT->addChild('DRIVES');
@@ -381,7 +372,7 @@ XML;
       }
 
       $i = 0;
-      foreach ($PluginSccmSccm->getMedias($this->device_id) as $value) {
+      foreach ($this->sccm->getMedias($this->device_id) as $value) {
          $CONTENT->addChild('STORAGES');
          $STORAGES = $this->sxml->CONTENT[0]->STORAGES[$i];
          $STORAGES->addChild('DESCRIPTION', $value['Med-Description']);

--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -198,6 +198,15 @@ XML;
       }
    }
 
+   private function addCDataToNode(SimpleXMLElement $node, $value = '')
+   {
+      if ($domElement = dom_import_simplexml($node))
+      {
+         $domOwner = $domElement->ownerDocument;
+         $domElement->appendChild($domOwner->createCDATASection("{$value}"));
+      }
+   }
+
    function setSoftwares() {
 
       $antivirus = []; $inject_antivirus = false;
@@ -209,13 +218,15 @@ XML;
 
          if (isset($value['ArPd-DisplayName']) && preg_match("#&#", $value['ArPd-DisplayName'])) {
             $value['ArPd-DisplayName'] = preg_replace("#&#", "&amp;", $value['ArPd-DisplayName']);
+            $value['ArPd-DisplayName'] = preg_replace('/[\x00-\x1f]/','',htmlspecialchars($value['ArPd-DisplayName']));
          }
 
          if (isset($value['ArPd-Publisher']) && preg_match("#&#", $value['ArPd-Publisher'])) {
             $value['ArPd-Publisher'] = preg_replace("#&#", "&amp;", $value['ArPd-Publisher']);            
          }
 
-         $SOFTWARES->addChild('NAME', $value['ArPd-DisplayName'] ?: NOT_AVAILABLE);
+         $NAME = $SOFTWARES->addChild('NAME');
+         $this->addCDataToNode($NAME, $value['ArPd-DisplayName'] ?: NOT_AVAILABLE);
 
          if (isset($value['ArPd-Version'])) {
             $SOFTWARES->addChild('VERSION', $value['ArPd-Version']);


### PR DESCRIPTION
Hi all!

I have make some changes to support my requeriments.
We have 2 SCCM servers, the first is small and we manage only ours virtual servers, the second is too big, is used over several organizations, ours computers are in a specific SCCM Collection, there are more that 3 thousand computers but we only work with computers in a specific collection.

Well I need to have several SCCM server configurations and I need to specify which collection I want to synchronize.

The changes are:

* Modify `config.form.php`. When is loaded this show a list of configurations, if `id` parameter is setted show configuration with this id, if `id` not exist show create form. Update when post with `update` and Add new when post with `add`,
* Modify `config.class.php`. Add `sccm_config_name` and `sccm_collection_name` fields, set `id` as `AUTO_INCREMENT`. Add method to show configuration list.
* Modify `sccm.class.php`. Add parameter `configId` to all methods that access to database to get SCCM data. On `executeCollect` and `executePush` iterate over configurations to collect and push from active configurations. Add SQL to `getComputerQuery` to discriminate by collection.

What is missing?
* Option to remove a configuration.
* Change "home.php", "showtable.php", I don't know what these files are for.
* Modify test.php. I don't know how to try the tests.
* Correct breadcrumb.


What would be desirable?
* I think the best would be to show standard entity list page to manage configurations. I have tried to use `Search::show('PluginSccmConfig');` but it not show fields, add button, ... 
![image](https://user-images.githubusercontent.com/247167/237056506-df583c95-c214-4ad7-ab6f-7c2ef734b32b.png)

If you would like to add this to repository I would like to get some help to complete it.

Can you help me?