### PR TITLE
Add network type

### DIFF
--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -323,6 +323,31 @@ XML;
       $USERS->addChild('LOGIN', $this->username);
    }
 
+   function determineNetworkType($network_description) {
+      $description = strtolower($network_description);
+
+      $networkTypes = [
+        'wifi' => ['wi-fi', 'wireless', 'wifi'],
+        'infiniband' => ['infiniband'],
+        'aggregate' => ['aggregation', 'aggregate'],
+        'alias' => ['alias'],
+        'dialup' => ['dialup', 'dial-up'],
+        'loopback' => ['loop'],
+        'bridge' => ['bridge'],
+        'fibrechannel' => ['fibre', 'fiber'],
+        'bluetooth' => ['bluetooth'],
+      ];
+
+      foreach ($networkTypes as $type => $keywords) {
+         foreach ($keywords as $keyword) {
+            if (str_contains($description, $keyword)) {
+                return $type;
+            }
+         }
+      }
+      return "ethernet";
+   }
+
    function setNetworks() {
 
       $PluginSccmSccm = new PluginSccmSccm();
@@ -354,6 +379,7 @@ XML;
                $NETWORKS->addChild('IPDHCP', $value['ND-DHCPServer']);
                $NETWORKS->addChild('IPGATEWAY', $value['ND-IpGateway']);
                $NETWORKS->addChild('MACADDR', $value['ND-MacAddress']);
+               $NETWORKS->addChild('TYPE', $this->determineNetworkType($value['ND-Name']));
 
                $i++;
             }


### PR DESCRIPTION
Hi guys! nice to be here again, I have several commits to bring here but I want to start with this.

We have noticed that network ports of computers imported by SCCM plugin didn't have network port type, I assume type were null. They didn't have "Ethernet port" section in "networkport.form.php". If we look at the computer history we can see that inventory have remove old ports (created by hand) and it have created the new ports but they are without port type.

Well after research I could see this _glpi-agent_ issue where @stonebuzz warns that **_type_** node is missing: https://github.com/glpi-project/glpi-agent/issues/236#issuecomment-1277152257
And this oder where Kofee88 show the XML, like SCCM plugin generates, where type node is included: https://github.com/glpi-project/glpi/issues/14086#issuecomment-1431320635

I'm not sure where to add this node, I have thought that if the network have IP it have to be a ethernet port.

I have try this and now all my computer network ports have ethernet section, they are typed as *NetworkPortEthernet*.

Is ok? some changes suggested?

Thanks in advance!