### PR TITLE
Avoid use explode with null value

### DIFF
--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -338,7 +338,7 @@ XML;
          foreach ($networks as $value) {
             //SCCM database store each IP format in one row, we need to split it
             //and add each IP in dedicated XML node
-            $parts = explode(",", $value['ND-IpAddress']);
+            $parts = explode(",", $value['ND-IpAddress'] ?? '');
             foreach ($parts as $ip) {
                $CONTENT->addChild('NETWORKS');
                $NETWORKS = $this->sxml->CONTENT[0]->NETWORKS[$i];


### PR DESCRIPTION
We get deprecated warning in logs, the message is:

    Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in

With this the message disappear.