### PR TITLE
Clear special chars from software names

### DIFF
--- a/inc/sccmxml.class.php
+++ b/inc/sccmxml.class.php
@@ -196,6 +196,15 @@ XML;
       }
    }
 
+   private function addCDataToNode(SimpleXMLElement $node, $value = '')
+   {
+      if ($domElement = dom_import_simplexml($node))
+      {
+         $domOwner = $domElement->ownerDocument;
+         $domElement->appendChild($domOwner->createCDATASection("{$value}"));
+      }
+   }
+
    function setSoftwares() {
 
       $PluginSccmSccm = new PluginSccmSccm();
@@ -209,13 +218,15 @@ XML;
 
          if (isset($value['ArPd-DisplayName']) && preg_match("#&#", $value['ArPd-DisplayName'])) {
             $value['ArPd-DisplayName'] = preg_replace("#&#", "&amp;", $value['ArPd-DisplayName']);
+            $value['ArPd-DisplayName'] = preg_replace('/[\x00-\x1f]/','',htmlspecialchars($value['ArPd-DisplayName']));
          }
 
          if (isset($value['ArPd-Publisher']) && preg_match("#&#", $value['ArPd-Publisher'])) {
             $value['ArPd-Publisher'] = preg_replace("#&#", "&amp;", $value['ArPd-Publisher']);
          }
 
-         $SOFTWARES->addChild('NAME', $value['ArPd-DisplayName'] ?: NOT_AVAILABLE);
+         $NAME = $SOFTWARES->addChild('NAME');
+         $this->addCDataToNode($NAME, $value['ArPd-DisplayName'] ?: NOT_AVAILABLE);
 
          if (isset($value['ArPd-Version'])) {
             $SOFTWARES->addChild('VERSION', $value['ArPd-Version']);


### PR DESCRIPTION
The last one (I think :D )

We were having problems with some software names, it was coming with special chars that they broke the xml format, after try several ways I decide to clear software name string of special chars and include it in a CDATA xml node.
This way:

```
    <SOFTWARES>
      <NAME><![CDATA[Xamarin Offline Packages]]></NAME>
      <VERSION>16.10.5</VERSION>
      <PUBLISHER>Xamarin</PUBLISHER>
      <INSTALLDATE>21/06/2021</INSTALLDATE>
    </SOFTWARES>
    <SOFTWARES>
      <NAME><![CDATA[Xamarin PCL Profiles v1.0.9]]></NAME>
      <VERSION>1.0.9.0</VERSION>
      <PUBLISHER>Xamarin</PUBLISHER>
      <INSTALLDATE>03/01/2018</INSTALLDATE>
    </SOFTWARES>
    <SOFTWARES>
      <NAME><![CDATA[Xamarin Remoted iOS Simulator]]></NAME>
      <VERSION>17.3.0.492</VERSION>
      <PUBLISHER>Xamarin</PUBLISHER>
      <INSTALLDATE>15/02/2023</INSTALLDATE>
    </SOFTWARES>
    <SOFTWARES>
      <NAME><![CDATA[Надстройка Microsoft Report Viewer для Visual Studio 2013]]></NAME>
      <VERSION>11.1.3442.2</VERSION>
      <PUBLISHER>Microsoft Corporation</PUBLISHER>
      <INSTALLDATE>03/09/2014</INSTALLDATE>
    </SOFTWARES>
    <SOFTWARES>
      <NAME><![CDATA[Пакет Visual Studio 2012 Verification SDK - rus]]></NAME>
      <VERSION>12.0.30501</VERSION>
      <PUBLISHER>Microsoft Corporation</PUBLISHER>
      <INSTALLDATE>03/09/2014</INSTALLDATE>
    </SOFTWARES>
    <SOFTWARES>
      <NAME><![CDATA[用于 Visual Studio 2013 的 Microsoft 报告查看器加载项]]></NAME>
      <VERSION>11.1.3442.2</VERSION>
      <PUBLISHER>Microsoft Corporation</PUBLISHER>
      <INSTALLDATE>03/09/2014</INSTALLDATE>
    </SOFTWARES>
```