### PR TITLE
Fix(Core): drop mssql_connect prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix config page error on display
 - Fix `password` value not saved
+- Drop `mssql_connect` prerequisites
 
 ## [2.5.0] - 2025-10-01
 

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -43,12 +43,6 @@ class PluginSccmSccm
             );
         }
 
-        if (!function_exists('mssql_connect')) {
-            throw new BadRequestHttpException(
-                __s('MSSQL extension (PHP) is required... !!', 'sccm'),
-            );
-        }
-
         if (!function_exists('sqlsrv_connect')) {
             throw new BadRequestHttpException(
                 __s('SQLSRV extension (PHP) is required... !!', 'sccm'),


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Remove the unnecessary prerequisite for `mssql_connect`, as this function is never called.

Fix #154 


## Screenshots (if appropriate):
