### PR TITLE
2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-[UNRELEASED]
+## [2.5.1] - 2025-10-07
+
+Compatible with GLPI 11.0.x
 
 ### Fixed
 
 - Fix config page error on display
 - Fix `password` value not saved
 - Drop `mssql_connect` prerequisites
+- Fix option ```verify_ssl_cert``` not working for connections
 
 ## [2.5.0] - 2025-10-01
 
@@ -19,12 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - GLPI 11 compatibility
 
-### Fixed
-
-- Fix option ```verify_ssl_cert``` not working for connections
-
-
 ## [2.4.4] - 2025-09-24
+
+Compatible with GLPI 10.0.x
 
 ### Added
 

--- a/sccm.xml
+++ b/sccm.xml
@@ -48,9 +48,19 @@ Prerequisite :
    </authors>
    <versions>
       <version>
+         <num>2.5.1</num>
+         <compatibility>~11.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/sccm/releases/download/2.5.1/glpi-sccm-2.5.1.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.5.0</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/sccm/releases/download/2.5.0/glpi-sccm-2.5.0.tar.bz2</download_url>
+      </version>
+      <version>
+         <num>2.4.5</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/sccm/releases/download/2.4.5/glpi-sccm-2.4.5.tar.bz2</download_url>
       </version>
       <version>
          <num>2.4.4</num>

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_SCCM_VERSION', '2.5.0');
+define('PLUGIN_SCCM_VERSION', '2.5.1');
 define("PLUGIN_SCCM_MIN_GLPI", "11.0.00");
 define("PLUGIN_SCCM_MAX_GLPI", "11.0.99");
 


### PR DESCRIPTION
## [2.5.1] - 2025-10-07

Compatible with GLPI 11.0.x

### Fixed

- Fix config page error on display
- Fix `password` value not saved
- Drop `mssql_connect` prerequisites
- Fix option ```verify_ssl_cert``` not working for connections