### PR TITLE
Feat: add install-ext make target for sqlsrv dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,9 @@
 include ../../PluginsMakefile.mk
+
+install-ext: ## Install PHP extensions required by this plugin (sqlsrv). Re-run after any container rebuild.
+	$(COMPOSE) exec --user root app bash -c "\
+		apt-get update -yq \
+		&& apt-get install -yq --no-install-recommends unixodbc-dev \
+		&& rm -rf /var/lib/apt/lists/* \
+		&& pecl install sqlsrv \
+		&& docker-php-ext-enable sqlsrv"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Plugin to synchronize computers from SCCM (version 1802) to GLPI.
 ![GLPISCCMPluginSchema](screenshots/schema.png "GLPISCCMPluginSchema")
 
 
+## Development setup
+
+This plugin requires the `sqlsrv` PHP extension (PECL), which is not included in the base GLPI development image.
+
+After starting the containers (`make` from the GLPI root), install it once:
+
+```bash
+make install-ext
+```
+
+Re-run this command after any container rebuild.
+
 ## Documentation
 
 We maintain a detailed documentation here -> [Documentation](https://glpi-plugins.readthedocs.io/en/latest/sccm/index.html)


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- Adds a `make install-ext` target that installs the `sqlsrv` PHP extension (PECL) inside the dev container.
- Documents the one-time setup step in README so contributors can get the plugin running after a container rebuild.
