### PR TITLE
Fix(XML): Sanitize invalid char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Sanitize invalid characters from SCCM
+
 ## [2.6.0] - 2026-05-26
 
 ### Added

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -41,6 +41,7 @@ use function Safe\simplexml_load_file;
 use function Safe\sqlsrv_fetch_array;
 use function Safe\mkdir;
 use function Safe\preg_replace;
+use function Safe\mb_convert_encoding;
 
 class PluginSccmSccm
 {
@@ -326,6 +327,7 @@ class PluginSccmSccm
             if (!is_string($v)) {
                 return $v;
             }
+
             // Fix invalid UTF-8 sequences before applying the XML character filter
             $v = mb_convert_encoding($v, 'UTF-8', 'UTF-8');
             // Remove all characters illegal in XML 1.0:

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -92,6 +92,7 @@ class PluginSccmSccm
         $this->devices = [];
 
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
+            $tab = self::sanitizeRow($tab);
             $tab['MD-SystemName'] = strtoupper((string) $tab['MD-SystemName']);
             $this->devices[] = $tab;
             $i++;
@@ -118,7 +119,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = $tab;
+            $data[] = self::sanitizeRow($tab);
             $i++;
         }
 
@@ -145,7 +146,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = $tab;
+            $data[] = self::sanitizeRow($tab);
             $i++;
         }
 
@@ -177,7 +178,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = $tab;
+            $data[] = self::sanitizeRow($tab);
             $i++;
         }
 
@@ -207,7 +208,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = $tab;
+            $data[] = self::sanitizeRow($tab);
             $i++;
         }
 
@@ -233,7 +234,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = $tab;
+            $data[] = self::sanitizeRow($tab);
             $i++;
         }
 
@@ -255,7 +256,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = $tab;
+            $data[] = self::sanitizeRow($tab);
             $i++;
         }
 
@@ -286,7 +287,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = $tab;
+            $data[] = self::sanitizeRow($tab);
             $i++;
         }
 
@@ -311,11 +312,25 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = $tab;
+            $data[] = self::sanitizeRow($tab);
             $i++;
         }
 
         return $data;
+    }
+
+    private static function sanitizeRow(array $row): array
+    {
+        return array_map(static function ($v) {
+            if (!is_string($v)) {
+                return $v;
+            }
+            if (($pos = strpos($v, "\0")) !== false) {
+                $v = substr($v, 0, $pos);
+            }
+            $v = mb_scrub($v, 'UTF-8');
+            return preg_replace('/[\x{FFFE}\x{FFFF}]/u', '', $v) ?? '';
+        }, $row);
     }
 
     public static function install(): void

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -40,6 +40,7 @@ use function Safe\realpath;
 use function Safe\simplexml_load_file;
 use function Safe\sqlsrv_fetch_array;
 use function Safe\mkdir;
+use function Safe\preg_replace;
 
 class PluginSccmSccm
 {
@@ -92,7 +93,7 @@ class PluginSccmSccm
         $this->devices = [];
 
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $tab = self::sanitizeRow($tab);
+            $tab = $this->sanitizeRow($tab);
             $tab['MD-SystemName'] = strtoupper((string) $tab['MD-SystemName']);
             $this->devices[] = $tab;
             $i++;
@@ -119,7 +120,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = self::sanitizeRow($tab);
+            $data[] = $this->sanitizeRow($tab);
             $i++;
         }
 
@@ -146,7 +147,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = self::sanitizeRow($tab);
+            $data[] = $this->sanitizeRow($tab);
             $i++;
         }
 
@@ -178,7 +179,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = self::sanitizeRow($tab);
+            $data[] = $this->sanitizeRow($tab);
             $i++;
         }
 
@@ -208,7 +209,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = self::sanitizeRow($tab);
+            $data[] = $this->sanitizeRow($tab);
             $i++;
         }
 
@@ -234,7 +235,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = self::sanitizeRow($tab);
+            $data[] = $this->sanitizeRow($tab);
             $i++;
         }
 
@@ -256,7 +257,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = self::sanitizeRow($tab);
+            $data[] = $this->sanitizeRow($tab);
             $i++;
         }
 
@@ -287,7 +288,7 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = self::sanitizeRow($tab);
+            $data[] = $this->sanitizeRow($tab);
             $i++;
         }
 
@@ -312,22 +313,24 @@ class PluginSccmSccm
         $data = [];
         $i    = 0;
         while (($tab = sqlsrv_fetch_array($result, SQLSRV_FETCH_ASSOC)) && $i < $limit) {
-            $data[] = self::sanitizeRow($tab);
+            $data[] = $this->sanitizeRow($tab);
             $i++;
         }
 
         return $data;
     }
 
-    private static function sanitizeRow(array $row): array
+    private function sanitizeRow(array $row): array
     {
         return array_map(static function ($v) {
             if (!is_string($v)) {
                 return $v;
             }
+
             if (($pos = strpos($v, "\0")) !== false) {
                 $v = substr($v, 0, $pos);
             }
+
             $v = mb_scrub($v, 'UTF-8');
             return preg_replace('/[\x{FFFE}\x{FFFF}]/u', '', $v) ?? '';
         }, $row);

--- a/inc/sccm.class.php
+++ b/inc/sccm.class.php
@@ -326,13 +326,15 @@ class PluginSccmSccm
             if (!is_string($v)) {
                 return $v;
             }
-
-            if (($pos = strpos($v, "\0")) !== false) {
-                $v = substr($v, 0, $pos);
-            }
-
-            $v = mb_scrub($v, 'UTF-8');
-            return preg_replace('/[\x{FFFE}\x{FFFF}]/u', '', $v) ?? '';
+            // Fix invalid UTF-8 sequences before applying the XML character filter
+            $v = mb_convert_encoding($v, 'UTF-8', 'UTF-8');
+            // Remove all characters illegal in XML 1.0:
+            // U+0000–U+0008, U+000B, U+000C, U+000E–U+001F, U+FFFE, U+FFFF
+            return preg_replace(
+                '/[^\x{0009}\x{000A}\x{000D}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u',
+                '',
+                $v,
+            ) ?? '';
         }, $row);
     }
 

--- a/tests/PluginSccmSccmTest.php
+++ b/tests/PluginSccmSccmTest.php
@@ -109,7 +109,7 @@ class PluginSccmSccmTest extends GLPITestCase
 
         $this->assertNotFalse($loaded, 'XML must be loadable after sanitization');
         $this->assertEmpty($errors, 'No libxml errors expected');
-        $this->assertSame('PublisherWithControlChars', (string) $loaded->PUBLISHER);
+        $this->assertSame('PublisherWithControlCharstrailing', (string) $loaded->PUBLISHER);
     }
 
     public function testGetcomputerQueryBaseStructure(): void

--- a/tests/PluginSccmSccmTest.php
+++ b/tests/PluginSccmSccmTest.php
@@ -74,7 +74,7 @@ class PluginSccmSccmTest extends GLPITestCase
     public static function illegalXmlCharProvider(): iterable
     {
         yield 'null byte NCHAR padding'        => ["Intel\x00\x00\x00",           'Intel'];
-        yield 'null byte mid-string'           => ["Inte\x00l",                   'Inte'];
+        yield 'null byte mid-string'           => ["Inte\x00l",                   'Intel'];
         yield 'U+FFFE noncharacter'            => ["Intel\xEF\xBF\xBE",           'Intel'];
         yield 'U+FFFF noncharacter'            => ["Intel\xEF\xBF\xBF",           'Intel'];
         yield 'U+FFFE and U+FFFF combined'     => ["Corp\xEF\xBF\xBE\xEF\xBF\xBF", 'Corp'];

--- a/tests/PluginSccmSccmTest.php
+++ b/tests/PluginSccmSccmTest.php
@@ -95,7 +95,7 @@ class PluginSccmSccmTest extends GLPITestCase
             "<?xml version='1.0' encoding='UTF-8'?><R><PUBLISHER></PUBLISHER></R>",
         );
         $sxml->PUBLISHER[0] = $result['pub'];
-        $file = tempnam(sys_get_temp_dir(), 'sccm_test_') . '.ocs';
+        $file = sys_get_temp_dir() . '/sccm_test_' . uniqid() . '.ocs';
         $sxml->asXML($file);
 
         libxml_use_internal_errors(true);

--- a/tests/PluginSccmSccmTest.php
+++ b/tests/PluginSccmSccmTest.php
@@ -30,9 +30,88 @@
  */
 
 use Glpi\Tests\GLPITestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PluginSccmSccmTest extends GLPITestCase
 {
+    private function callSanitizeRow(array $row): array
+    {
+        $sccm = $this->getMockBuilder(PluginSccmSccm::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        return (new \ReflectionMethod(PluginSccmSccm::class, 'sanitizeRow'))->invoke($sccm, $row);
+    }
+
+    public function testSanitizeRowPreservesCleanString(): void
+    {
+        $result = $this->callSanitizeRow(['name' => 'Intel(R) Corporation']);
+        $this->assertSame('Intel(R) Corporation', $result['name']);
+    }
+
+    public function testSanitizeRowPreservesNonStringValues(): void
+    {
+        $result = $this->callSanitizeRow(['int' => 42, 'null' => null, 'bool' => true]);
+        $this->assertSame(42, $result['int']);
+        $this->assertNull($result['null']);
+        $this->assertTrue($result['bool']);
+    }
+
+    public function testSanitizeRowPreservesValidXmlWhitespace(): void
+    {
+        $result = $this->callSanitizeRow(['ws' => "line1\ttabbed\nline2\rreturn"]);
+        $this->assertSame("line1\ttabbed\nline2\rreturn", $result['ws']);
+    }
+
+    #[DataProvider('illegalXmlCharProvider')]
+    public function testSanitizeRowStripsIllegalXmlChars(string $input, string $expected): void
+    {
+        $result = $this->callSanitizeRow(['v' => $input]);
+        $this->assertSame($expected, $result['v']);
+    }
+
+    public static function illegalXmlCharProvider(): iterable
+    {
+        yield 'null byte NCHAR padding'        => ["Intel\x00\x00\x00",           'Intel'];
+        yield 'null byte mid-string'           => ["Inte\x00l",                   'Inte'];
+        yield 'U+FFFE noncharacter'            => ["Intel\xEF\xBF\xBE",           'Intel'];
+        yield 'U+FFFF noncharacter'            => ["Intel\xEF\xBF\xBF",           'Intel'];
+        yield 'U+FFFE and U+FFFF combined'     => ["Corp\xEF\xBF\xBE\xEF\xBF\xBF", 'Corp'];
+        yield 'SOH U+0001'                     => ["Intel\x01Corp",               'IntelCorp'];
+        yield 'control chars U+0001–U+0008'    => ["A\x01\x02\x03\x04\x05\x06\x07\x08Z", 'AZ'];
+        yield 'vertical tab U+000B'            => ["Intel\x0BCorp",               'IntelCorp'];
+        yield 'form feed U+000C'               => ["Intel\x0CCorp",               'IntelCorp'];
+        yield 'control chars U+000E–U+001F'    => ["A\x0E\x0F\x10\x1FZ",         'AZ'];
+        yield 'issue #181 production value'    => [
+            "Intel(R) Corporation\xEF\xBF\xBE\xEF\xBF\xBF",
+            'Intel(R) Corporation',
+        ];
+    }
+
+    public function testSanitizeRowProducesLoadableXml(): void
+    {
+        $dirty = "Publisher\x01With\x0BControl\xEF\xBF\xBFChars\x00trailing";
+        $result = $this->callSanitizeRow(['pub' => $dirty]);
+
+        $sxml = new SimpleXMLElement(
+            "<?xml version='1.0' encoding='UTF-8'?><R><PUBLISHER></PUBLISHER></R>",
+        );
+        $sxml->PUBLISHER[0] = $result['pub'];
+        $file = tempnam(sys_get_temp_dir(), 'sccm_test_') . '.ocs';
+        $sxml->asXML($file);
+
+        libxml_use_internal_errors(true);
+        $loaded = simplexml_load_file($file, 'SimpleXMLElement', LIBXML_NOCDATA);
+        $errors = libxml_get_errors();
+        libxml_clear_errors();
+        unlink($file);
+
+        $this->assertNotFalse($loaded, 'XML must be loadable after sanitization');
+        $this->assertEmpty($errors, 'No libxml errors expected');
+        $this->assertSame('PublisherWithControlChars', (string) $loaded->PUBLISHER);
+    }
+
     public function testGetcomputerQueryBaseStructure(): void
     {
         $query = PluginSccmSccm::getcomputerQuery();

--- a/tests/PluginSccmSccmTest.php
+++ b/tests/PluginSccmSccmTest.php
@@ -36,10 +36,7 @@ class PluginSccmSccmTest extends GLPITestCase
 {
     private function callSanitizeRow(array $row): array
     {
-        $sccm = $this->getMockBuilder(PluginSccmSccm::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
+        $sccm = (new \ReflectionClass(PluginSccmSccm::class))->newInstanceWithoutConstructor();
 
         return (new \ReflectionMethod(PluginSccmSccm::class, 'sanitizeRow'))->invoke($sccm, $row);
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

SCCM stores certain metadata in fixed-length `NCHAR` database fields. In some cases, these fields may contain trailing null bytes, residual binary data, or Unicode non-characters such as `U+FFFE` and `U+FFFF`. When this data is exported into XML files, it can introduce characters that are not valid according to the XML 1.0 specification.

As a result, the inventory import or push process may fail with an XML parsing error, preventing successful processing of the generated file.

**Example of a corrupted value observed in production environments:**
```xml
<PUBLISHER>Intel(R) Corporation쩗ኮ᠀耀��</PUBLISHER>
```

And should be 
```xml
<PUBLISHER>Intel(R) Corporation쩗ኮ᠀耀￿￿</PUBLISHER>
```

In this example, unexpected trailing characters are appended to the publisher name. These characters originate from corrupted or improperly sanitized database content and generate invalid XML output, leading to parsing failures during downstream processing.


 Fixes #181



## Screenshots (if appropriate):
